### PR TITLE
Update eMMC boot partition directly in bfinst

### DIFF
--- a/bfinst
+++ b/bfinst
@@ -422,7 +422,7 @@ if [ -z "${skip_boot_update}" ]; then
     # MUST be executed after 'install_grub', otherwise the newly
     # created boot option would be either cleaned up or unset
     # from default option.
-    /opt/mlnx/scripts/bfrec
+    /opt/mlnx/scripts/bfrec --bootctl
 fi
 
 # Execute miscellaneous tasks. These are vendor/customer specific


### PR DESCRIPTION
The current bfinst uses capsule by default to upgrade the eMMC
boot partition in next boot. It relies on the old boot images
to be working and compatible with latest FW which might have
been upgraded, or else the upgrade will fail. This commit tries
to update the boot partition directly. The capsule update is
preserved in case it's needed later for secure boot or the boot
partition is locked.