### PR TITLE
Use mlxbf-bootctl to update boot partition in bfinst

### DIFF
--- a/bfinst
+++ b/bfinst
@@ -431,7 +431,7 @@ if [ -z "${skip_boot_update}" ]; then
     # MUST be executed after 'install_grub', otherwise the newly
     # created boot option would be either cleaned up or unset
     # from default option.
-    /opt/mlnx/scripts/bfrec
+    /opt/mlnx/scripts/bfrec --bootctl
 fi
 
 # Execute miscellaneous tasks. These are vendor/customer specific


### PR DESCRIPTION
This commit changes to use mlxbf-bootctl to update boot
partition when calling bfrec in bfinst. Previously
it uses capsule upgrade which relies on the old boot
images to be working and compatible with latest FW.