### PR TITLE
Fix eMMC partition naming and UUID assignment

### DIFF
--- a/bfpart
+++ b/bfpart
@@ -74,11 +74,12 @@ bfcfg_scan()
       eval "part_persist=\${DISK${disk}_PART${part}_PERSIST}"
       eval "part_mount=\${DISK${disk}_PART${part}_MOUNT}"
 
-      if [ "${part_type}" = "EFI" ]; then
+      # Evaluate and assign partition UUID information.
+      if [ "${part_type}" = "EFI" ] || [ "${part_type}" = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" ]; then
         part_type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         part_uuid=3DCADB7E-BCCC-4897-A766-3C070EDD7C25
       else
-        if [ "${part_type}" = "LINUX" ]; then
+        if [ "${part_type}" = "LINUX" ] || [ "${part_type}" = "0FC63DAF-8483-4772-8E79-3D69D8477DE4" ]; then
           part_type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
         fi
         if [ -n "${part_persist}" ]; then


### PR DESCRIPTION
A previous issue existed where the DISK{}_PART{}_TYPE value
was being assigned the partition UUID after the first call of the
bcfg() function. However, the partition name value was then lost
and could not be accessed during the second call of this function.
In order to ensure that the part_type value used for partition UUID
assignment is a name, and not a UUID, a conditional structure was
implemented to catch this and switch the UUID back to a name before
entering the partition UUID assignment block.

RM: #2164870