### PR TITLE
bfcfg: Fix getting the MAC address for BF2 cards

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -352,7 +352,7 @@ boot_cfg_add_ipv6()
 #
 boot_cfg()
 {
-  local i tmp idx entry ifname proto mac vlan vlan_len
+  local i tmp idx entry ifname proto mac vlan vlan_len disk_entry_idx
   local shell_entry disk_entries boot_order
   local tmp_dir=/tmp/.boot_cfg
   local tmp_file=${tmp_dir}/boot
@@ -377,7 +377,6 @@ boot_cfg()
       shell_entry=$(efibootmgr 2>/dev/null | grep "EFI Internal Shell" | cut -c5-8)
       cp -f ${efivars}/Boot"${shell_entry}"* ${tmp_dir}/shell
     fi
-
   done
 
   # Don't continue if nothing configured.
@@ -400,7 +399,17 @@ boot_cfg()
     entry=$(echo "${entry}" | tr '[:lower:]' '[:upper:]')
 
     # BOOT<N> = DISK
-    [ ."${entry}" = ."DISK" ] && continue
+    if [ ."${entry}" = ."DISK" ]; then
+      disk_entry_idx=64
+      for i in $disk_entries; do
+        tmp=$(printf '%04x' ${disk_entry_idx})
+        cp "${tmp_dir}/Boot${i}-${efi_global_var_guid}" "${efivars}/Boot${tmp}-${efi_global_var_guid}"
+        [ -n "${boot_order}" ] && boot_order="${boot_order},"
+        boot_order="${boot_order}${tmp}"
+        disk_entry_idx=$((disk_entry_idx + 1))
+      done
+      continue
+    fi
 
     # BOOT<N> = UEFI_SHELL
     if [ ."${entry}" = ."UEFI_SHELL" ]; then
@@ -539,14 +548,6 @@ boot_cfg()
       boot_order="${boot_order}${tmp}"
       idx=$((idx + 1))
     fi 
-  done
-
-  for i in $disk_entries; do
-    tmp=$(printf '%04x' ${idx})
-    cp "${tmp_dir}/Boot${i}-${efi_global_var_guid}" "${efivars}/Boot${tmp}-${efi_global_var_guid}"
-    [ -n "${boot_order}" ] && boot_order="${boot_order},"
-    boot_order="${boot_order}${tmp}"
-    idx=$((idx + 1))
   done
 
   efibootmgr -o "${boot_order}" >/dev/null

--- a/bfcfg
+++ b/bfcfg
@@ -464,10 +464,13 @@ boot_cfg()
 
       NIC_P0|NIC_P1)
         [ ! -d /dev/mst ] && mst start
-        mac=$(flint -d /dev/mst/mt41682_pciconf0 q | grep "^Base MAC" | awk '{print $3}')
-        if [ -z "${mac}" ]; then
-          log_msg "boot: failed to get MAC for ${entry}"
-          continue
+        mac=$(flint -d /dev/mst/mt41682_pciconf0 q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
+        if [ -z "${mac}" ] || [ ."${mac}" = ."N/A" ]; then
+          mac=$(flint -d /dev/mst/mt41686_pciconf0 q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
+          if [ -z "${mac}" ] || [ ."${mac}" = ."N/A" ]; then
+            log_msg "boot: failed to get MAC for ${entry}"
+            continue
+          fi
         fi
         mac="0x${mac}"
         if [ "${ifname}" = "NIC_P0" ]; then


### PR DESCRIPTION
This commit fixes the command to get MAC address for BF2 cards.
It also checks the possible 'NA' result when MAC is not set.