### PR TITLE
Add spec file and Makefile to build SRPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+RPMBUILD
+oe-workdir
+oe-logs
+git_dir_pack
+*.src.rpm

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ clean:
 RPMBUILD/SOURCES/$(TAR_NAME): $(GIT_FILES)
 	mkdir -p RPMBUILD/SOURCES
 	rm -rf git_dir_pack
-	mkdir -p git_dir_pack/bfscripts
-	rsync --relative $(GIT_FILES) git_dir_pack/bfscripts
-	(cd git_dir_pack; tar -zcvf ../$@ bfscripts)
+	mkdir -p git_dir_pack/mlxbf-bfscripts
+	rsync --relative $(GIT_FILES) git_dir_pack/mlxbf-bfscripts
+	(cd git_dir_pack; tar -zcvf ../$@ mlxbf-bfscripts)
 
 $(SRPM_NAME): RPMBUILD/SOURCES/$(TAR_NAME) bfscripts.spec
 	rpmbuild -bs --define "_topdir $(shell pwd)/RPMBUILD" bfscripts.spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+RPM_BASE:=$(shell rpmspec --query bfscripts.spec)
+SRPM_NAME:=$(subst .noarch,,$(RPM_BASE)).src.rpm
+GIT_FILES:=$(shell git ls-files -co --exclude-standard)
+
+.PHONY: all clean
+all: $(SRPM_NAME)
+
+clean:
+	rm -r RPMBUILD
+	rm -r git_dir_pack
+	rm -f mlxbf-bfscripts*.src.rpm
+
+RPMBUILD/SOURCES/mlxbf-bfscripts.tar.gz: $(GIT_FILES)
+	mkdir -p RPMBUILD/SOURCES
+	rm -rf git_dir_pack
+	mkdir -p git_dir_pack/bfscripts
+	rsync --relative $(GIT_FILES) git_dir_pack/bfscripts
+	(cd git_dir_pack; tar -zcvf ../$@ bfscripts)
+
+$(SRPM_NAME): RPMBUILD/SOURCES/mlxbf-bfscripts.tar.gz \
+  bfscripts.spec
+	rpmbuild -bs --define "_topdir $(shell pwd)/RPMBUILD" bfscripts.spec
+	cp RPMBUILD/SRPMS/$(SRPM_NAME) ./

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ clean:
 RPMBUILD/SOURCES/$(TAR_NAME): $(GIT_FILES)
 	mkdir -p RPMBUILD/SOURCES
 	rm -rf git_dir_pack
-	mkdir -p git_dir_pack/mlxbf-bfscripts
-	rsync --relative $(GIT_FILES) git_dir_pack/mlxbf-bfscripts
-	(cd git_dir_pack; tar -zcvf ../$@ mlxbf-bfscripts)
+	mkdir -p git_dir_pack/$(TAR_BASE)
+	rsync --relative $(GIT_FILES) git_dir_pack/$(TAR_BASE)
+	(cd git_dir_pack; tar -zcvf ../$@ $(TAR_BASE))
 
 $(SRPM_NAME): RPMBUILD/SOURCES/$(TAR_NAME) bfscripts.spec
 	rpmbuild -bs --define "_topdir $(shell pwd)/RPMBUILD" bfscripts.spec

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-RPM_BASE:=$(shell rpmspec --query bfscripts.spec)
-SRPM_NAME:=$(subst .noarch,,$(RPM_BASE)).src.rpm
+RPM_BASE:=$(shell \
+  rpmspec --query --qf "%{name}-%{version}-%{release}" bfscripts.spec)
+SRPM_NAME:=$(RPM_BASE).src.rpm
+TAR_BASE:=$(shell \
+  rpmspec --query --qf "%{name}-%{version}" bfscripts.spec)
+TAR_NAME:=$(TAR_BASE).tar.gz
 GIT_FILES:=$(shell git ls-files -co --exclude-standard)
 
 .PHONY: all clean
@@ -10,14 +14,13 @@ clean:
 	rm -r git_dir_pack
 	rm -f mlxbf-bfscripts*.src.rpm
 
-RPMBUILD/SOURCES/mlxbf-bfscripts.tar.gz: $(GIT_FILES)
+RPMBUILD/SOURCES/$(TAR_NAME): $(GIT_FILES)
 	mkdir -p RPMBUILD/SOURCES
 	rm -rf git_dir_pack
 	mkdir -p git_dir_pack/bfscripts
 	rsync --relative $(GIT_FILES) git_dir_pack/bfscripts
 	(cd git_dir_pack; tar -zcvf ../$@ bfscripts)
 
-$(SRPM_NAME): RPMBUILD/SOURCES/mlxbf-bfscripts.tar.gz \
-  bfscripts.spec
+$(SRPM_NAME): RPMBUILD/SOURCES/$(TAR_NAME) bfscripts.spec
 	rpmbuild -bs --define "_topdir $(shell pwd)/RPMBUILD" bfscripts.spec
 	cp RPMBUILD/SRPMS/$(SRPM_NAME) ./

--- a/bfscripts.spec
+++ b/bfscripts.spec
@@ -1,0 +1,101 @@
+%global debug_package %{nil}
+
+Summary: Utility scripts for managing Mellanox BlueField hardware
+Name: mlxbf-bfscripts
+Version: 3.0.0~beta1
+URL: https://github.com/Mellanox/bfscripts
+Release: 1%{?dist}
+License: BSD
+
+BuildArch: noarch
+
+Source: mlxbf-bfscripts.tar.gz
+
+BuildRequires: systemd
+BuildRequires: python3-devel
+BuildRequires: /usr/bin/pathfix.py
+
+Requires: mlxbf-bootctl
+Requires: mlxbf-aarch64-firmware
+Requires: bash
+Requires: python
+Requires: grub2-tools
+Requires: dosfstools
+Requires: e2fsprogs
+Requires: efibootmgr
+Requires: pciutils
+Requires: util-linux
+Requires: binutils
+
+%description
+Useful scripts for managing Mellanox BlueField hardware.
+
+%prep
+%setup -q -n bfscripts
+pathfix.py -pni "%{__python3} %{py3_shbang_opts}" mlx-mkbfb
+
+%build
+exit 0
+
+%install
+%global installdir %{buildroot}%{_bindir}
+%global man1dir %{buildroot}%{_mandir}/man1
+%global man8dir %{buildroot}%{_mandir}/man8
+mkdir -p %{installdir}
+%{__install} -d %{man1dir}
+%{__install} -d %{man8dir}
+
+%{__install} bfbootmgr        %{installdir}
+%{__install} man/bfbootmgr.8  %{man8dir}
+%{__install} bfcfg            %{installdir}
+%{__install} man/bfcfg.8      %{man8dir}
+%{__install} bfcpu-freq       %{installdir}
+%{__install} man/bfcpu-freq.8 %{man8dir}
+%{__install} bfdracut         %{installdir}
+%{__install} man/bfdracut.8   %{man8dir}
+%{__install} bffamily         %{installdir}
+%{__install} man/bffamily.8   %{man8dir}
+%{__install} bfinst           %{installdir}
+%{__install} man/bfinst.8     %{man8dir}
+%{__install} bfpxe            %{installdir}
+%{__install} man/bfpxe.8      %{man8dir}
+%{__install} bfrec            %{installdir}
+%{__install} man/bfrec.8      %{man8dir}
+%{__install} bfsbkeys         %{installdir}
+%{__install} man/bfsbkeys.8   %{man8dir}
+%{__install} bfvcheck         %{installdir}
+%{__install} man/bfvcheck.8   %{man8dir}
+%{__install} bfver            %{installdir}
+%{__install} man/bfver.8      %{man8dir}
+%{__install} bfauxpwr         %{installdir}
+%{__install} man/bfauxpwr.8   %{man8dir}
+
+%{__install} mlx-mkbfb       %{installdir}
+%{__install} man/mlx-mkbfb.1 %{man1dir}
+
+mkdir -p %{buildroot}%{_unitdir}/
+install bfvcheck.service %{buildroot}%{_unitdir}/
+
+%post
+systemctl enable bfvcheck.service
+systemctl daemon-reload
+systemctl start bfvcheck.service >/dev/null 2>&1
+
+%preun
+systemctl stop bfvcheck.service >/dev/null 2>&1
+systemctl disable bfvcheck.service
+systemctl daemon-reload
+
+%files
+%license LICENSE
+/usr/bin/bf*
+/usr/bin/mlx-mkbfb
+%attr(644, root, root) %{_mandir}/man1/*
+%attr(644, root, root) %{_mandir}/man8/*
+%attr(644, root, root) %{_unitdir}/bfvcheck.service
+
+%doc README.md
+
+%changelog
+* Wed Jul 1 2020 Spencer Lingard <spencer@nvidia.com> - 3.0.0~beta1-1
+Initial packaging.

--- a/bfscripts.spec
+++ b/bfscripts.spec
@@ -31,7 +31,7 @@ Requires: binutils
 Useful scripts for managing Mellanox BlueField hardware.
 
 %prep
-%setup -q -n mlxbf-bfscripts
+%setup -q
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" mlx-mkbfb
 
 %build

--- a/bfscripts.spec
+++ b/bfscripts.spec
@@ -31,7 +31,7 @@ Requires: binutils
 Useful scripts for managing Mellanox BlueField hardware.
 
 %prep
-%setup -q -n bfscripts
+%setup -q -n mlxbf-bfscripts
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" mlx-mkbfb
 
 %build

--- a/bfscripts.spec
+++ b/bfscripts.spec
@@ -9,7 +9,7 @@ License: BSD
 
 BuildArch: noarch
 
-Source: mlxbf-bfscripts.tar.gz
+Source: %{name}-%{version}.tar.gz
 
 BuildRequires: systemd
 BuildRequires: python3-devel


### PR DESCRIPTION
Some systems do not have up to date versions of rpkg available,
so add a generated spec file and a Makefile that can build SRPMs
from the generated spec file.