### PR TITLE
bfinst: call bfrec after installation

### DIFF
--- a/bfinst
+++ b/bfinst
@@ -433,3 +433,6 @@ if [ -z "${skip_boot_update}" ]; then
     # from default option.
     bfrec --bootctl
 fi
+
+# Update configuration in case it's overwritten by bfinst
+bfcfg


### PR DESCRIPTION
It was found that some configuration created by bfcfg was overwriteen
by bfinst. This commit calls bfcfg again to avoid such issue.