### PR TITLE
bfrec: Run under bash to fix on Ubuntu

### DIFF
--- a/bfrec
+++ b/bfrec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (c) 2020, Mellanox Technologies
 # All rights reserved.


### PR DESCRIPTION
bfrec has an issue running under Ubuntu's interpreter, dash. For now,
switch the interpreter to bash.