### PR TITLE
Remove direct references to flint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Overview of each file:
 - **bfcpu-freq** Display Arm core frequency.
 - **bfdracut** Create an initramfs.
 - **bffamily** Display the BlueField family for the particular board.
-- **bfhcafw** Utilities for managing ConnectX firmware.
+- **bfhcafw** Utilities for managing ConnectX interfaces on BlueField.
 - **bfinst** Simple installation script for both the bootloader and a root file
   system.
 - **bfpxe** PXE boot helper script.

--- a/bfcfg
+++ b/bfcfg
@@ -472,14 +472,10 @@ boot_cfg()
         ;;
 
       NIC_P0|NIC_P1)
-        [ ! -d /dev/mst ] && mst start
-        mac=$(flint -d /dev/mst/mt41682_pciconf0 q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
+        mac=$(bfhcafw flint q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
         if [ -z "${mac}" ] || [ ."${mac}" = ."N/A" ]; then
-          mac=$(flint -d /dev/mst/mt41686_pciconf0 q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
-          if [ -z "${mac}" ] || [ ."${mac}" = ."N/A" ]; then
-            log_msg "boot: failed to get MAC for ${entry}"
-            continue
-          fi
+          log_msg "boot: failed to get MAC for ${entry}"
+          continue
         fi
         mac="0x${mac}"
         if [ "${ifname}" = "NIC_P0" ]; then

--- a/bfhcafw
+++ b/bfhcafw
@@ -29,11 +29,22 @@
 
 usage () {
     cat >&2 <<EOF
-usage: bfhcafw [-h|--help] find
+usage: bfhcafw [-h|--help] [find | flint <FLINT_ARGS...>]
 
-Various utilities for ConnectX firmware on BlueField systems. Currently there
-is only one command: find, which searches the filesystem for the correct
-ConnectX firmware image for the current system and prints the full path to it.
+Various utilities for ConnectX interface on BlueField systems. Supports the
+following commands:
+
+find    Searches the filesystem for the correct ConnectX firmware image for
+        the current system and prints the full path to it.
+
+flint   Automatically selects the correct flint binary, and passes in the PCI
+        device path for the ConnectX interface.
+
+        bfhcafw flint query
+
+        is equivalent to:
+
+        (mst)flint -d <BF1 or BF2 PCI path> query
 EOF
 }
 
@@ -43,8 +54,10 @@ err () {
 
 BASE_FW_NAME=mlxfwmanager_sriov_dis_aarch64
 
-# Set mlxfw filename based on current system
-set_mlxfw_name () {
+CHIPNUM_BF1=41682
+CHIPNUM_BF2=41686
+
+get_chipnum () {
     if ! [ -e /sys/firmware/acpi/tables ]; then
         err "fatal: cannot find acpi tables"
         exit 1
@@ -61,7 +74,12 @@ set_mlxfw_name () {
         chipnum=41682
     fi
 
-    mlxfw_name="${BASE_FW_NAME}_${chipnum}"
+    echo $chipnum
+}
+
+# Set mlxfw filename based on current system
+set_mlxfw_name () {
+    mlxfw_name="${BASE_FW_NAME}_$(get_chipnum)"
 }
 
 # Finds the FW file on the system and sets $mlxfw accordingly.
@@ -92,6 +110,25 @@ find_fw () {
     return 1
 }
 
+find_flint () {
+    if command -v mstflint >/dev/null; then
+        echo mstflint
+    elif command -v flint >/dev/null; then
+        echo flint
+    else
+        err "err: cannot find flint executable"
+        exit 1
+    fi
+}
+
+get_pci_path () {
+    echo $(lspci | grep '00\.0.*BlueField.*ConnectX' | cut -f1 -d' ')
+}
+
+run_flint () {
+    $(find_flint) -d $(get_pci_path) $@
+}
+
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     usage
     exit 0
@@ -105,6 +142,9 @@ if [ "$1" = "find" ]; then
         err "err: the firmware package could not be located"
         exit 1
     fi
+elif [ "$1" = "flint" ]; then
+    shift
+    run_flint $@
 else
     err "err: unknown cmd"
     usage

--- a/man/bfhcafw.8
+++ b/man/bfhcafw.8
@@ -1,4 +1,4 @@
-.TH BFFINDFW 8 "July 2020"
+.TH BFFINDFW 8 "October 2020"
 .SH NAME
 bfhcafw \- Utilities for BlueField ConnectX firmware
 .SH SYNOPSIS
@@ -7,14 +7,20 @@ bfhcafw \- Utilities for BlueField ConnectX firmware
 .PP
 .B bfhcafw
 find
+.PP
+.B bfhcafw
+flint FLINT_ARGS
 .SH DESCRIPTION
-A collection of utilities for managing ConnectX firmware on BlueField systems.
-The functionality of this utility is divided into commands, of which there is
-currently only one:
+A collection of utilities for managing ConnectX interfaces on BlueField
+systems. The functionality of this utility is divided into commands:
 .IP find
 Searches the filesystem for the ConnectX firmware distribution appropriate
 for the current BlueField hardware revision and linux distribution, and prints
 the absolute file path to stdout.
+.IP flint FLINT_ARGS
+Automatically picks the mstflint executable and PCI device path to run
+flint. Automatically selects the -d argument based on platform, all other
+arguments are passed to flint.
 .SH OPTIONS
 .IP "-h | --help"
 Print a short help message.


### PR DESCRIPTION
In order to improve compatability, remove the direct use of the
proprietary "flint" executable, preferring mstflint where available.
Also, do not depend on mst for the PCI conf device.