### PR TITLE
bfrec: Remove the argument when calling bfrec

### DIFF
--- a/bfinst
+++ b/bfinst
@@ -433,7 +433,7 @@ if [ -z "${skip_boot_update}" ]; then
     # MUST be executed after 'install_grub', otherwise the newly
     # created boot option would be either cleaned up or unset
     # from default option.
-    bfrec --bootctl
+    bfrec
 fi
 
 # Update configuration in case it's overwritten by bfinst


### PR DESCRIPTION
This commit removes the extra argument "--bootctl" when calling
bfrec because bfrec has been improved to select the default
boot record update method automatically in order to support UEFI
secure-boot.