### PR TITLE
Add informative message for linux being up (#77)

### DIFF
--- a/bfvcheck.service
+++ b/bfvcheck.service
@@ -4,6 +4,7 @@ After=getty.target
 
 [Service]
 Type=idle
+ExecStartPre=/usr/bin/bfrshlog "Linux up"
 ExecStart=/usr/bin/bfvcheck
 StandardOutput=journal+console
 


### PR DESCRIPTION
Customer has requested for the BF to report that
linux has completed booting via the rshim
Their BMC is the rshim host.

To do that, bfrshlog will be called from the
bfvcheck.service to report that linux is up
since the bfvcheck service is scheduled to run
once the login prompt appears.

RM #2326964

Co-authored-by: Asmaa Mnebhi <asmaa@nvidia.com>