### PR TITLE
Abstract ConnectX references in bffamily

### DIFF
--- a/bffamily
+++ b/bffamily
@@ -47,8 +47,7 @@ if [ "$bfversion" = $BF1_PLATFORM_ID ]; then
         ["Poondion"]="MBF1M706A-CSNAT_C15"
         ["Poondion BF1700"]="MBF1M716A-CSNAT"
     )
-    BUS_NUMBER=$(lspci | grep -E "Mellanox.+MT416842\s+BlueField.+ConnectX-5" | grep -m 1 -oE "[0-9]{2}:[0-9]{2}.[0-9]")
-    PART_NUMBER=$(lspci -s "$BUS_NUMBER" -vv | grep PN)
+    PART_NUMBER=$(lspci -s "$(bfhcafw bus)" -vv | grep PN)
 
 elif [ "$bfversion" = $BF2_PLATFORM_ID ]; then
 
@@ -62,8 +61,7 @@ elif [ "$bfversion" = $BF2_PLATFORM_ID ]; then
         ["BlueForce"]="BLUEFORCE_IPN"
         ["BlueSphere"]="(MBS2M512A|BS2M512A)"
     )
-    BUS_NUMBER=$(lspci | grep -E "Mellanox.+MT42822\s+BlueField.+ConnectX-6" | grep -m 1 -oE "[0-9]{2}:[0-9]{2}.[0-9]")
-    PART_NUMBER=$(flint -d $BUS_NUMBER dc | grep -m1 "name =" | cut -f 3 -d " ")
+    PART_NUMBER=$(bfhcafw flint dc | grep -m1 "name =" | cut -f 3 -d " ")
 else
     echo "Unknown platform"
     exit 1

--- a/bfhcafw
+++ b/bfhcafw
@@ -29,7 +29,11 @@
 
 usage () {
     cat >&2 <<EOF
-usage: bfhcafw [-h|--help] [find | flint <FLINT_ARGS...>]
+usage: bfhcafw [-h|--help]
+       bfhcafw find
+       bfhcafw flint <FLINT ARGS...>
+       bfhcafw mcra <MCRA ARGS...>
+       bfhcafw bus
 
 Various utilities for ConnectX interface on BlueField systems. Supports the
 following commands:
@@ -48,6 +52,8 @@ flint   Automatically selects the correct flint binary, and passes in the PCI
 
 mcra    Similar to flint, automatically selects binary and PCI conf path to
         run mcra.
+
+bus     Prints the PCI bus number for the ConnectX interface.
 EOF
 }
 
@@ -173,6 +179,9 @@ elif [ "$1" = "flint" ]; then
 elif [ "$1" = "mcra" ]; then
     shift
     run_mcra $@
+elif [ "$1" = "bus" ]; then
+    shift
+    echo $(get_pci_path)
 else
     err "err: unknown cmd"
     usage

--- a/man/bfhcafw.8
+++ b/man/bfhcafw.8
@@ -13,6 +13,9 @@ flint FLINT_ARGS
 .PP
 .B bfhcafw
 mcra MCRA_ARGS
+.PP
+.B bfhcafw
+bus
 .SH DESCRIPTION
 A collection of utilities for managing ConnectX interfaces on BlueField
 systems. The functionality of this utility is divided into commands:
@@ -28,6 +31,8 @@ arguments are passed to flint.
 Automatically picks the mstmcra executable and PCI device path to run
 mcra. Automatically selects the device argument based on platform, all other
 arguments are passed to mcra.
+.IP bus
+Prints the PCI device path for the current BlueField hardware platform.
 .SH OPTIONS
 .IP "-h | --help"
 Print a short help message.


### PR DESCRIPTION
- Run references to ConnectX through bfhcafw
- Add new "bus" command to bfhcafw that just prints correct PCI bus
  number for current platform