### PR TITLE
Add mlx-uefi.quirk file for fwupd

### DIFF
--- a/debian/mlxbf-scripts.install
+++ b/debian/mlxbf-scripts.install
@@ -1,3 +1,4 @@
 bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfinst usr/bin/
 bfpart bfpxe bfrec bfrshlog bfsbkeys bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
 bfvcheck.service lib/systemd/system/
+mlx-uefi.quirk usr/share/fwupd/quirks.d/

--- a/mlx-uefi.quirk
+++ b/mlx-uefi.quirk
@@ -1,0 +1,3 @@
+# NVIDIA Mellanox BlueField 1, 2
+[Guid=39342586-4e0e-4833-b4ba-1256b0ffb471]
+VersionFormat = quad

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -90,6 +90,11 @@ install -p bfvcheck.service %{buildroot}%{_unitdir}/
 install -p -d %{buildroot}%{_presetdir}
 install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 
+# Install tweak for fwupd on BlueField
+%global fwupdquirkdir %{buildroot}%{_datadir}/fwupd/quirks.d
+install -p -d %{fwupdquirkdir}
+install -p mlx-uefi.quirk %{fwupdquirkdir}/
+
 %post
 %systemd_post bfvcheck.service
 
@@ -107,6 +112,7 @@ install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 %attr(644, root, root) %{_mandir}/man8/*
 %attr(644, root, root) %{_unitdir}/bfvcheck.service
 %attr(644, root, root) %{_presetdir}/80-bfvcheck.preset
+%attr(644, root, root) %{_datadir}/fwupd/quirks.d/mlx-uefi.quirk
 
 %doc README.md
 

--- a/mlxbf-bfscripts.spec.rpkg
+++ b/mlxbf-bfscripts.spec.rpkg
@@ -90,6 +90,11 @@ install -p bfvcheck.service %{buildroot}%{_unitdir}/
 install -p -d %{buildroot}%{_presetdir}
 install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 
+# Install tweak for fwupd on BlueField
+%global fwupdquirkdir %{buildroot}%{_datadir}/fwupd/quirks.d
+install -p -d %{fwupdquirkdir}
+install -p mlx-uefi.quirk %{fwupdquirkdir}/
+
 %post
 %systemd_post bfvcheck.service
 
@@ -107,6 +112,7 @@ install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 %attr(644, root, root) %{_mandir}/man8/*
 %attr(644, root, root) %{_unitdir}/bfvcheck.service
 %attr(644, root, root) %{_presetdir}/80-bfvcheck.preset
+%attr(644, root, root) %{_datadir}/fwupd/quirks.d/mlx-uefi.quirk
 
 %doc README.md
 


### PR DESCRIPTION
Temporary tweak to enable fwupd support on BF hardware until quirk
can be added to fwupd project