### PR TITLE
bfcfg: display error if only one MFG parameter specified

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -59,6 +59,12 @@ mfg_cfg()
     return
   fi
 
+  if [ -n "${MFG_OOB_MAC}" -a -z "${MFG_OPN_STR}" ] ||
+     [ -z "${MFG_OOB_MAC}" -a -n "${MFG_OPN_STR}" ]; then
+    echo "ERROR: both MFG_OOB_MAC and MFG_OPN_STR must be specified"
+    echo "       in order to write information to the MFG partition."
+  fi
+
   if [ -n "${MFG_OOB_MAC}" ] && [ -e "${oob_mac_sysfs}" ] && [ -n "${MFG_OPN_STR}" ] && [ -e "${opn_str_sysfs}" ]; then
     log_msg "mfg: OOB_MAC=${MFG_OOB_MAC}"
     echo "${MFG_OOB_MAC}" > ${oob_mac_sysfs} 2>>${log_file}


### PR DESCRIPTION
The current logic in 'bfcfg' will log a warning if only one
of the two MFG parameters (OOB_MAC and OPN_STR) are specified.
In this case, there is no error displayed to the user, only to
the 'bfcfg' log.  This patch adds logic to display an error
message to the user if only one MFG parameter is specified.