### PR TITLE
bfrshlog: display the logging buffer if no argument

### DIFF
--- a/bfrshlog
+++ b/bfrshlog
@@ -29,9 +29,10 @@
 
 rshlog_path="/sys/devices/platform/MLNXBF04:00/driver/rsh_log"
 
-if [ -e "${rshlog_path}" ]; then
-  echo "$*" > "${rshlog_path}"
-else
-  echo "$*"
-fi
+[ ! -e "${rshlog_path}" ] && exit
 
+if [ $# -eq 0 ]; then
+  cat "${rshlog_path}" 2>/dev/null
+else
+  echo "$*" > "${rshlog_path}"
+fi


### PR DESCRIPTION
This commit enhances bfrshlog to display the current rshim logging
buffer if no argument is provided.