### PR TITLE
Fix the bffamily script

### DIFF
--- a/bffamily
+++ b/bffamily
@@ -64,9 +64,9 @@ elif [ "$bfversion" = $BF2_PLATFORM_ID ]; then
         ["Camelantis"]="MBF2H512C"
         ["Aztlan"]="MBF2(H51|M51|H53)6C"
         ["OVH"]="SSN4MELX100200"
-        ["Dell Camelantis"]="0JNDCM"
+        ["Dell-Camelantis"]="0JNDCM"
     )
-    PART_NUMBER=$(bfhcafw flint dc | grep -m1 "name =" | cut -f 3 -d " ")
+    PART_NUMBER=$(bfhcafw flint q full | grep "Part Number:" | cut -f 2 -d ":" | xargs)
 else
     echo "Unknown platform"
     exit 1


### PR DESCRIPTION
On Dell Camelantis, bffamily fails because bfhcafw fails with the
following error:
root@localhost:~# bfhcafw flint dc
-E- Failed dumping Fw Configuration : Unsupported operation under Secure FW

Replace that command with mlxfwmanager to retrieve the OPN.

Also, replace the space in "Dell Camelantis" with "-".