### PR TITLE
bfver: Remove SIG prefix for trap

### DIFF
--- a/bfver
+++ b/bfver
@@ -30,7 +30,7 @@
 PROGNAME=$(basename "$0")
 TMP_DIR=$(mktemp -d)
 trap "rm -rf $TMP_DIR" EXIT
-trap "rm -rf $TMP_DIR; exit 1" SIGTERM SIGINT
+trap "rm -rf $TMP_DIR; exit 1" TERM INT
 
 usage ()
 {


### PR DESCRIPTION
The trap utility does not accept SIGTERM/SIGINT under the Ubuntu/Debian
shell, dash. This causes bfvcheck to fail on startup. Change
SIGTERM and SIGINT to TERM and INT.