### PR TITLE
Move psc-fw before BL2

### DIFF
--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -53,6 +53,7 @@ from optparse import OptionParser, OptionGroup
 image_list = (
     # Images for ATF
     ("psc-bl",    "PSC bootloader image",                  36),
+    ("psc-fw",    "PSC framework image",                  37),
     ("bl2r-cert", "RIoT Core (BL2R) content certificate",  31),
     ("bl2r",      "RIoT Core (BL2R) bin",                  30),
     ("bl2-cert",  "Trusted Boot Firmware BL2 certificate", 6),
@@ -62,7 +63,6 @@ image_list = (
     ("snps_images", "Combined SNPS Images for all DIMM types", 33),
     ("ddr_ate_imem", "Analog Test Engine INSTRUCTIONS", 34),
     ("ddr_ate_dmem", "Analog Test Engine DATA", 35),
-    ("psc-fw",    "PSC framework image",                  37),
     ("bl30-key-cert", "SCP Firmware BL3-0 key certificate", 8),
     ("bl30-cert", "SCP Firmware BL3-0 certificate", 12),
     ("bl30", "SCP Firmware BL3-0", 2),


### PR DESCRIPTION
Move psc-fw before the BL2 image for BL2 decryption. It also help
avoid potential conflict between the image loading of BL2 and PSC
BL1/FW.