### PR TITLE
Cleanup bfacpievt script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A public collection of useful scripts to help manage the Mellanox BlueField
 SoC.
 
 Overview of each file:
-- **bfacpievt** Config ACPI daemon to handle AUX power mode and reset events.
+- **bfacpievt** Config ACPI daemon to handle AUX power mode.
 - **bfbootmgr** Change boot options.
 - **bfcfg** Processes a config file passed over the rshim device.
 - **bfcpu-freq** Display Arm core frequency.

--- a/bfacpievt
+++ b/bfacpievt
@@ -32,7 +32,7 @@
 usage()
 {
   cat <<EOF
-Usage: $0 [--help] [--update-low-pwr] [--update-reset]
+Usage: $0 [--help] [--update-low-pwr]
 EOF
 }
 
@@ -85,47 +85,6 @@ echo 441 > /sys/class/gpio/unexport
   fi
 }
 
-update_reset()
-{
-  powerconf=/etc/acpi/events/powerconf
-  powercontrol=/etc/acpi/actions/powercontrol
-  systemdconf=/etc/systemd/logind.conf
-
-  mkdir -p /etc/acpi/events
-  echo \
-"event=button/power.*
-action=$powercontrol
-" > $powerconf
-
-  mkdir -p /etc/acpi/actions
-  echo \
-"#!/bin/bash
-
-reboot
-" > $powercontrol
-
-  chmod +x $powercontrol
-
-  systemctl restart acpid
-
-  echo "Acpid config updated."
-
-  if [ -f "$systemdconf" ]; then
-    configexist=$(grep -c '^HandlePowerKey=ignore' $systemdconf)
-    otherconfig=$(grep -c '^HandlePowerKey' $systemdconf)
-    if [ "$configexist" -ge 1 ]; then
-      echo "Systemd config exists. Done."
-    elif [ "$otherconfig" -ge 1 ]; then
-      echo "Please remove systemd HandlePowerKey setting and try again."
-    else
-      echo "HandlePowerKey=ignore" >> $systemdconf
-      echo "Systemd config has been updated. Please reboot the system."
-    fi
-  else
-    echo "Please check systemd config file if HandlePowerKey is set to ignore."
-  fi
-}
-
 while true
 do
   case $1 in
@@ -135,10 +94,6 @@ do
           ;;
       --update-low-pwr)
           update_low_pwr
-          exit 0
-          ;;
-      --update-reset)
-          update_reset
           exit 0
           ;;
       *)

--- a/bffamily
+++ b/bffamily
@@ -61,10 +61,12 @@ elif [ "$bfversion" = $BF2_PLATFORM_ID ]; then
         ["BlueForce"]="BLUEFORCE_IPN"
         ["BlueSphere"]="(MBS2M512(A|C)|BS2M512A)"
         ["PRIS"]="699210020215"
-        ["Camelantis"]="MBF2H512C"
+        ["Camelantis"]="MBF2H5(1|3)2C"
         ["Aztlan"]="MBF2(H51|M51|H53)6C"
         ["OVH"]="SSN4MELX100200"
         ["Dell-Camelantis"]="0JNDCM"
+        ["El-Dorado"]="MBF2M355A"
+        ["Roy"]="6992100402(05|06|30|31)"
     )
     PART_NUMBER=$(bfhcafw flint q full | grep "Part Number:" | cut -f 2 -d ":" | xargs)
 else

--- a/man/bfacpievt.8
+++ b/man/bfacpievt.8
@@ -6,18 +6,11 @@ bfacpievt \- Create configuration files to handle acpi events.
 .RB [ \-\-help | \-h ]
 .PP
 .B bfacpievt --update-acpi-low-pwr
-.PP
-.B bfacpievt --update-acpi-rst
 .SH DESCRIPTION
 Create configuration files to handle acpi events. Currently, this script is
-only applicable to OCP 3.0 to handle low power mode and the BlueSphere card
-to trigger reboot.
+only applicable to OCP 3.0 to handle low power mode.
 .SH OPTIONS
 .IP --update-low-pwr
 Disable power button event handling in systemd, and configure the ACPI daemon
 to handle AUX power events by powering up/down all secondary cores. This option
 is only valid for the OCP 3.0 card.
-.IP --update-reset
-Disable power button event handling in systemd, and configure the ACPI daemon
-to handle reset events by rebooting the BlueField-2. This option is only valid
-for rhe BlueSphere.


### PR DESCRIPTION
Remove all code related to GPIO 7 reset from bfacpievt.
Add new OPNs to bffamily:
1) El Dorado: MBF2M355A
2) Camelantis: MBF2H532C