### PR TITLE
Fix the get_hca_p0_mac function in bfcfg

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -358,16 +358,36 @@ boot_cfg_add_name()
 # shellcheck disable=SC2140
 boot_cfg_add_pcie()
 {
-  printf \
-"\\x02\\x01\\x0c\\x00\\xd0\\x41\\x03\\x0a\\x00\\x00\\x00\\x00"\
-"\\x01\\x01\\x06\\x00\\x00\\x00\\x01\\x01\\x06\\x00\\x00\\x00"\
-"\\x01\\x01\\x06\\x00\\x00\\x02\\x01\\x01\\x06\\x00" >> "$1"
-  if [ "$2" = "NIC_P0" ]; then
-    printf "\\x00" >> "$1"
-  else
-    printf "\\x01" >> "$1"
+  local idx address dev_id func_id dev_path cnt
+
+  # Get PCI path
+  dev_path=$(lspci -t | head -n 1 | grep -o "[0-9][0-9]\.[0-9]*")
+  if [ -z "${dev_path}" ]; then
+    ${ECHO} "Failed to find device path"
+    return
   fi
-  printf "\\x00" >> "$1"
+
+  # PciRoot
+  printf "\\x02\\x01\\x0c\\x00\\xd0\\x41\\x03\\x0a\\x00\\x00\\x00\\x00" >> "$1"
+
+  idx=1
+  cnt=$(echo ${dev_path} | wc -w)
+  for address in ${dev_path}; do
+    # Type(1B)/SubType(1B)/Len(2B)
+    printf "\\x01\\x01\\x06\\x00" >> "$1"
+
+    # Get DevId and FuncId
+    dev_id=$(echo ${address} | tr '.' ' ' | awk '{print $1}')
+    func_id=$(echo ${address} | tr '.' ' ' | awk '{print $2}')
+
+    # Adjust FuncId for P1
+    if [ "$idx" -eq ${cnt} -a "$2" = "NIC_P1" ]; then
+      func_id=$((func_id + 1))
+    fi
+
+    printf "\\x${func_id}\\x${dev_id}" >> "$1"
+    idx=$((idx + 1))
+  done
 }
 
 #

--- a/bfcfg
+++ b/bfcfg
@@ -435,14 +435,18 @@ boot_cfg_add_ipv6()
 
 get_hca_p0_mac()
 {
-  local dev devmac devid p0mac
+  local dev devmac devid p0mac devmac_oui
 
+  base_mac=$(bfhcafw flint q 2>/dev/null | grep "^Base MAC" | awk '{print $3}')
+  base_mac=$(echo $base_mac | cut -c1-6)
   p0mac="feffffffffff"
   for dev in /sys/class/net/*; do
     [ ! -f ${dev}/device/device ] && continue
     devid=$(cat ${dev}/device/device)
     [ ."${devid}" != ."0xa2d2" -a ."${devid}" != ."0xa2d6" ] && continue
     devmac=$(cat ${dev}/address | sed 's/://g' | tr '[:upper:]' '[:lower:]')
+    devmac_oui=$(echo ${devmac} | cut -c1-6)
+    [ ."${base_mac}" != ."$devmac_oui" ] && continue
     if [ "${devmac}" \< "${p0mac}" ]; then
       p0mac=${devmac}
     fi


### PR DESCRIPTION
Previously the get_hca_p0_mac funciton walks through all interfaces
by filtering the devid, which is not efficient with certain config
where multiple virtual interfaces are created with the same devid.

This commit checks the 3-byte OUI of the BASE-MAC to avoid such
problem.