### PR TITLE
mlx-mkbfb: append capsule prior to appending boot parameters

### DIFF
--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -79,6 +79,7 @@ image_list = (
     ("bl33", "Non-Trusted Firmware BL3-3 bin", 5),
 
     # Images for UEFI
+    ("capsule", "UEFI capsule image", 52),
     ("boot-acpi", "Name of the ACPI table", 55),
     ("boot-dtb", "Name of the dtb file", 56),
     ("boot-desc", "Default boot menu item description", 57),
@@ -86,7 +87,6 @@ image_list = (
     ("boot-args", "Arguments for boot image", 59),
     ("boot-timeout", "Boot menu timeout", 60),
     ("uefi-tests", "Specify what UEFI tests to run", 61),
-    ("capsule", "UEFI capsule image", 52),
     ("ramdisk", "RAM Disk image", 54),
     ("image", "Boot image", 62),
     ("initramfs", "In-memory filesystem", 63),


### PR DESCRIPTION
As the capsule is expected to be read before the boot parameters
(boot-desc, boot-path and boot-args), then generate the capsule
first. This will prevent the boot parameters from being overwritten
during UEFI BDS phase, if capsule update is enabled.