### PR TITLE
bfhcafw: fix call to mcra and flint in secure boot

### DIFF
--- a/bfhcafw
+++ b/bfhcafw
@@ -120,10 +120,10 @@ find_fw () {
 }
 
 find_flint () {
-    if command -v mstflint >/dev/null; then
-        echo mstflint
-    elif command -v flint >/dev/null; then
+    if command -v flint >/dev/null; then
         echo flint
+    elif command -v mstflint >/dev/null; then
+        echo mstflint
     else
         err "err: cannot find flint executable"
         exit 1
@@ -131,10 +131,10 @@ find_flint () {
 }
 
 find_mcra () {
-    if command -v mstmcra >/dev/null; then
-        echo mstmcra
-    elif command -v mcra >/dev/null; then
+    if command -v mcra >/dev/null; then
         echo mcra
+    elif command -v mstmcra >/dev/null; then
+        echo mstmcra
     else
         err "err: cannot find mcra executable"
         exit 1


### PR DESCRIPTION
In secure boot mode, using bffamily results in the following errors:
[  29.163873] Lockdown: mstmcra: direct PCI access is restricted; see man kernel_lockdown.7

This is because bffamily calls bfhcafw which calls mstmcra.
UEFI secure boot enables the kernel lockdown feature which blocks access by mstmcra.
So always check for the mcra command first, before mstmcra
and flint first before mstflint.

RM #2799334