### PR TITLE
mlx-mkbfb: Reserve an image ID for PSC applications

### DIFF
--- a/bfpxe
+++ b/bfpxe
@@ -98,7 +98,11 @@ EOF
     # IP address
     if [ "$ifaddr" = "dhcp" ]; then
       ifconfig "$ifname" 0.0.0.0 up
-      udhcpc -R -b -A 5 -T 3 -t 10 -i "$ifname"
+      if [ -x /sbin/dhclient ]; then
+        /sbin/dhclient "$ifname"
+      else
+        udhcpc -R -b -A 5 -T 3 -t 10 -i "$ifname"
+      fi
       if [ -n "$TMP_MNT" ]; then
         sed -i '/Address =/d' "$TMP_MNT"/etc/systemd/network/05-"${ifname}".network
         echo "DHCP = ipv4" >> "$TMP_MNT"/etc/systemd/network/05-"${ifname}".network

--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -71,6 +71,7 @@ image_list = (
     ("bl31-key-cert", "EL3 Runtime Firmware BL3-1 key certificate", 9),
     ("bl31-cert", "EL3 Runtime Firmware BL3-1 content certificate", 13),
     ("bl31", "EL3 Runtime Firmware BL3-1 bin", 3),
+    ("psc-app",   "PSC application image",                 39),
     ("bl32-key-cert", "Secure Payload BL3-2 (Trusted OS) key certificate", 10),
     ("bl32-cert", "Secure Payload BL3-2 (Trusted OS) content certificate", 14),
     ("bl32", "Secure Payload BL3-2 (Trusted OS) bin", 4),


### PR DESCRIPTION
This commit reserves an image ID for PSC applications, which will
be loaded into secure DRAM by ATF BL2.