### PR TITLE
bfpxe: increase wget $bfks timeout to 180 seconds

### DIFF
--- a/bfpxe
+++ b/bfpxe
@@ -182,7 +182,7 @@ if [ -n "$bfks" ]; then
   until wget "$bfks"; do
     sleep 3
     count=$((count+1))
-    if [ $count -eq 20 ]; then
+    if [ $count -eq 60 ]; then
       break
     fi
   done


### PR DESCRIPTION
* 60 seconds is not sufficient in some cases (slow oob_net0 connection on Camelon?)

Signed-off-by: Yurii Shestakov <yuriis@nvidia.com>