### PR TITLE
bfcfg: support HTTP boot entry creation

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -256,6 +256,8 @@ sys_cfg_one_byte()
 #   SYS_DISABLE_PCIE     33            1
 #   SYS_ENABLE_OPTEE     34            1
 #   SYS_ENABLE_I2C0      36            1
+#   SYS_DISABLE_FORCE_PXE_RETRY  37    1
+#   SYS_ENABLE_BMC_FIELD_MODE    38    1
 #
 sys_cfg()
 {
@@ -279,6 +281,8 @@ sys_cfg()
   sys_cfg_one_byte ${tmp_file} "DISABLE_PCIE" 33 "${SYS_DISABLE_PCIE}"
   sys_cfg_one_byte ${tmp_file} "ENABLE_OPTEE" 34 "${SYS_ENABLE_OPTEE}"
   sys_cfg_one_byte ${tmp_file} "ENABLE_I2C0" 36 "${SYS_ENABLE_I2C0}"
+  sys_cfg_one_byte ${tmp_file} "DISABLE_FORCE_PXE_RETRY" 37 "${SYS_DISABLE_FORCE_PXE_RETRY}"
+  sys_cfg_one_byte ${tmp_file} "ENABLE_BMC_FIELD_MODE" 38 "${SYS_ENABLE_BMC_FIELD_MODE}"
 
   if [ ${has_change} -eq 1 ]; then
     chattr -i ${sys_cfg_sysfs}
@@ -384,6 +388,15 @@ boot_cfg_add_len()
   len=$2
   len=$(printf '%04x' "${len}")
   printf "\\x${len:2:2}\\x${len:0:2}" >> "$1"
+}
+
+#
+# Add http into a boot entry
+# $1: output file
+#
+boot_cfg_add_http()
+{
+  printf "\\x03\\x18\\x04\\x00" >> "$1"
 }
 
 #
@@ -557,6 +570,7 @@ boot_cfg()
   local tmp_file=${tmp_dir}/boot
   local tmp_vlan_file=${tmp_dir}/vlan
   local value tmp_entry old_boot_order
+  local l4proto l4proto_len
 
   [ $dump_mode -eq 1 ] && return
 
@@ -626,11 +640,13 @@ boot_cfg()
       fi
       cp -f ${tmp_dir}/shell ${tmp_file}
     else
-      # BOOT<N> = NET-<NIC_P0 | NIC_P1 | OOB | RSHIM>[.<vlan-id>]-<IPV4 | IPV6>
+      # BOOT<N> = NET-<NIC_P0 | NIC_P1 | OOB | RSHIM>[.<vlan-id>]-<IPV4 | IPV6>[-HTTP]
       ifname=$(echo "${entry}" | cut -d '-' -f 2)
       proto=$(echo "${entry}" | cut -d '-' -f 3)
       vlan=""
       vlan_len=0
+      l4proto=$(echo "${entry}" | cut -d '-' -f 4)
+      l4proto_len=0
       if [[ "${ifname}" = *"."* ]]; then
         vlan=$(echo "${ifname}" | cut -d '.' -f 2)
         ifname=$(echo "${ifname}" | cut -d '.' -f 1)
@@ -645,6 +661,10 @@ boot_cfg()
         continue
       fi
 
+      if [ "${l4proto}" = "HTTP" ]; then
+        l4proto_len=4
+      fi
+
       boot_cfg_add_header "${tmp_file}"
 
       case "${ifname}" in
@@ -655,9 +675,9 @@ boot_cfg()
           continue
         fi
         if [ "${proto}" = "IPV4" ]; then
-          boot_cfg_add_len "${tmp_file}" $((68 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((68 + vlan_len + l4proto_len))
         else
-          boot_cfg_add_len "${tmp_file}" $((101 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((101 + vlan_len + l4proto_len))
         fi
         boot_cfg_add_name "${tmp_file}" "${entry}"
         ;;
@@ -671,9 +691,9 @@ boot_cfg()
         mac="${mac// /:}"
         mac=${mac: -17}
         if [ "${proto}" = "IPV4" ]; then
-          boot_cfg_add_len "${tmp_file}" $((68 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((68 + vlan_len + l4proto_len))
         else
-          boot_cfg_add_len "${tmp_file}" $((101 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((101 + vlan_len + l4proto_len))
         fi
         boot_cfg_add_name "${tmp_file}" "${entry}"
         ;;
@@ -692,9 +712,9 @@ boot_cfg()
         mac=$(echo ${mac:0:2}:${mac:2:2}:${mac:4:2}:${mac:6:2}:${mac:8:2}:${mac:10:2})
   
         if [ "${proto}" = "IPV4" ]; then
-          boot_cfg_add_len "${tmp_file}" $((104 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((104 + vlan_len + l4proto_len))
         else
-          boot_cfg_add_len "${tmp_file}" $((137 + vlan_len))
+          boot_cfg_add_len "${tmp_file}" $((137 + vlan_len + l4proto_len))
         fi
         boot_cfg_add_name ${tmp_file} "${entry}"
         boot_cfg_add_pcie "${tmp_file}" "${ifname}"
@@ -735,6 +755,10 @@ boot_cfg()
         boot_cfg_add_ipv4 "${tmp_file}"
       else
         boot_cfg_add_ipv6 "${tmp_file}"
+      fi
+
+      if [ "${l4proto}" = "HTTP" ]; then
+        boot_cfg_add_http "${tmp_file}"
       fi
 
       boot_cfg_add_tail "${tmp_file}"


### PR DESCRIPTION
This commit adds support for HTTP boot entry creation by adding "-HTTP" suffix to existing boot entres in bf.cfg.

It also adds two missing options for UEFI system config.

Co-authored-by: Liming Sun <limings@nvidia.com>