### PR TITLE
bfcfg: Support dumping of long dhcp_class_id

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -311,8 +311,7 @@ misc_cfg()
     # PXE DHCP Class Identifier.
     value=""
     if [ -f "${pxe_dhcp_class_id_sysfs}" ]; then
-      value=$(hexdump -C ${pxe_dhcp_class_id_sysfs} 2>/dev/null | head -1 | awk '{print $NF}')
-      value=$(echo ${value:5:-1})
+      value=$(hexdump -C ${pxe_dhcp_class_id_sysfs} 2>/dev/null | xxd -r -p)
     fi
     echo "misc: PXE_DHCP_CLASS_ID=${value}"
   else


### PR DESCRIPTION
The current 'bfcfg -d' command truncates the dhcp_class_id when it is longer than 12 characters. This commit fixes it by using xxd since the maximum length of dhcp_class_id has been increased from 9 to 32 in UEFI.