### PR TITLE
bfcfg: removing warning

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -311,7 +311,7 @@ misc_cfg()
     # PXE DHCP Class Identifier.
     value=""
     if [ -f "${pxe_dhcp_class_id_sysfs}" ]; then
-      value=$(hexdump -C ${pxe_dhcp_class_id_sysfs} 2>/dev/null | xxd -r -p)
+      value=$(xxd -s 4 -p ${pxe_dhcp_class_id_sysfs} 2>/dev/null | xxd -r -p)
     fi
     echo "misc: PXE_DHCP_CLASS_ID=${value}"
   else


### PR DESCRIPTION
This commit removes the 'warning: command substitution: ignored null byte in input' message on Ubuntu by skipping the first 4 bytes when displaying the PXE_DHCP_CLASS_ID UEFI variable. The first 4 bytes are fixed and not related to the content itself.