### PR TITLE
Reserve one image id for padding

### DIFF
--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -82,6 +82,7 @@ image_list = (
     ("bl33-key-cert", "Non-Trusted Firmware BL3-3 key certificate", 11),
     ("bl33-cert", "Non-Trusted Firmware BL3-3 content certificate", 15),
     ("bl33", "Non-Trusted Firmware BL3-3 bin", 5),
+    ("dummy", "Dummy data for padding", 41),
 
     # Images for UEFI
     ("capsule", "UEFI capsule image", 52),


### PR DESCRIPTION
BF3 requires some extra data in the boot partition to read in order to terminate the eMMC FSM when booting from eMMC. This change is added for this purpose.