### PR TITLE
bfscripts: Modify mlx-mkbfb to support new DOT Auth Certificate

### DIFF
--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -58,6 +58,7 @@ image_list = (
     ("psc-fw",    "PSC framework image",                  37),
     ("bl2r-cert", "RIoT Core (BL2R) content certificate",  31),
     ("bl2r",      "RIoT Core (BL2R) bin",                  30),
+    ("dot-auth-cert", "DOT AUTHCERT DER-encoded certificate", 42),
     ("bl2-cert",  "Trusted Boot Firmware BL2 certificate", 6),
     ("bl2",       "Trusted Boot Firmware BL2 bin",         1),
     ("sys",       "Running system's part number or PSID",  29),


### PR DESCRIPTION
Supports insertion of the DOT Auth Cert for debug BFBs. Version 1 of the cert to be used for BF2
Version 2 of the cert to be used for BF3

Tested offline via the cmdline:
./mlx-mkbfb --dot-auth-cert-v1 authcert-example.der default.bfb debug.bfb
./mlx-mkbfb --dot-auth-cert-v2 authcert-example.der default.bfb debug.bfb

RM #3322861