### PR TITLE
bffamily: Read OPN using mlxvpd instead of flint

### DIFF
--- a/bffamily
+++ b/bffamily
@@ -80,7 +80,7 @@ elif [ "$bfversion" = $BF3_PLATFORM_ID ]; then
 	["Moonraker"]="900-9D3B(4|6|8)-00(EN|PN|CC|CV|SC|SV|CN)-(EA|AA|DA|AB|FB)(0|A|B)"
 	["Goldeneye"]="900-9D3D4-00(EN|NN)-(GA|HA)(0|A|B)"
     )
-    PART_NUMBER=$(bfhcafw flint q full | grep "Part Number:" | cut -f 2 -d ":" | xargs)
+    PART_NUMBER=$(mlxvpd -d /dev/mst/mt41692_pciconf0 | grep "Part Number" | awk '{print $NF}')
 
 else
     echo "Unknown platform"


### PR DESCRIPTION
Currently, we use flint to read the PN. But looks like this info is not accurate, and reflects an internal PN from the FW INI, and not the official PN. So reading the PN info from the VPD should be more reliable.

Sample output using the current method:
root@localhost:/home/ubuntu# flint -d /dev/mst/mt41692_pciconf0 q full
Part Number:           900-9D3B4-00EN-E_QP_Ax
(The PN found above is not an official OPN but an internal one)

Using the VPD instead:
root@localhost:/home/ubuntu# mlxvpd -d /dev/mst/mt41692_pciconf0
  PN             Part Number             900-9D3B4-00EN-EAB
(This is the correct OPN to be used)

RM #3334340