### PR TITLE
bfhcafw, bfvcheck: Fix firmware searching

### DIFF
--- a/bfhcafw
+++ b/bfhcafw
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 
 # Copyright (c) 2020, Mellanox Technologies
 # All rights reserved.
@@ -54,11 +54,19 @@ mcra    Similar to flint, automatically selects binary and PCI conf path to
         run mcra.
 
 bus     Prints the PCI bus number for the ConnectX interface.
+
+Set the environment variable VERBOSE=1 to see more detailed output.
 EOF
 }
 
 err () {
     echo "bfhcafw: $@" >&2
+}
+
+info () {
+    if [ -n "$VERBOSE" ]; then
+        echo "bfhcafw: info: $@" >&2
+    fi
 }
 
 BASE_FW_NAME=mlxfwmanager_sriov_dis_aarch64
@@ -84,11 +92,13 @@ get_chipnum () {
     echo $chipnum
 }
 
-# Get the mlxfw filename based on current system and a specified base name.
+# Get the mlxfw filename based on current system and a specified base name
+# and separator.
 get_mlxfw_name () {
     # $1 - Base filename
+    # $2 - Separator
 
-    echo "$1-$(get_chipnum)"
+    echo "$1$2$(get_chipnum)"
 }
 
 # Search for FW file of a given filename in known locations
@@ -97,10 +107,12 @@ find_fw_with_name () {
 
     # Ubuntu location
     mlxfw="/opt/mellanox/mlnx-fw-updater/firmware/$1"
+    info "searching $mlxfw"
     if [ -f $mlxfw ]; then echo $mlxfw; return 0; fi
 
     # Yocto location
     mlxfw="/lib/firmware/mellanox/$1"
+    info "searching $mlxfw"
     if [ -f $mlxfw ]; then echo $mlxfw; return 0; fi
 
     return 1
@@ -111,8 +123,15 @@ find_fw_with_name () {
 find_fw_with_basename () {
     # $1 - FW Base name
 
-    echo $(find_fw_with_name $(get_mlxfw_name "$1"))
-    return $?
+    result=$(find_fw_with_name $(get_mlxfw_name "$1" -))
+    if [ $? -eq 0 ]; then echo $result; return 0; fi
+
+    # Need to try with _ as separator too, some older distributions use
+    # _ instead of -
+    result=$(find_fw_with_name $(get_mlxfw_name "$1" _))
+    if [ $? -eq 0 ]; then echo $result; return 0; fi
+
+    return 1
 }
 
 find_fw () {

--- a/bfhcafw
+++ b/bfhcafw
@@ -63,9 +63,9 @@ err () {
     echo "bfhcafw: $@" >&2
 }
 
-info () {
+debug () {
     if [ -n "$VERBOSE" ]; then
-        echo "bfhcafw: info: $@" >&2
+        echo "bfhcafw: debug: $@" >&2
     fi
 }
 
@@ -107,12 +107,12 @@ find_fw_with_name () {
 
     # Ubuntu location
     mlxfw="/opt/mellanox/mlnx-fw-updater/firmware/$1"
-    info "searching $mlxfw"
+    debug "searching $mlxfw"
     if [ -f $mlxfw ]; then echo $mlxfw; return 0; fi
 
     # Yocto location
     mlxfw="/lib/firmware/mellanox/$1"
-    info "searching $mlxfw"
+    debug "searching $mlxfw"
     if [ -f $mlxfw ]; then echo $mlxfw; return 0; fi
 
     return 1

--- a/bfvcheck
+++ b/bfvcheck
@@ -120,10 +120,13 @@ compare_versions "$BUILD_ATF" "$RUNTIME_ATF" "ATF"
 compare_versions "$BUILD_UEFI" "$RUNTIME_UEFI" "UEFI"
 
 if [ "$BUILD_FW" = "N/A" ]; then
+    BOARD_PN="$(lspci -s $(bfhcafw bus) -vv | grep '\[PN\]' | cut -d' ' -f4-)"
     cat << EOF
-WARNING: The bundled firmware manager ($mlxfw)
-does not recognize the current card. No recommended firmware can
-be determined.
+WARNING: The bundled firmware manager does not include firmware for
+this board. Recommended firmware version cannot be determined.
+
+Firmware Manager Path: $mlxfw
+Part Number: $BOARD_PN
 
 EOF
     version_error=ERR

--- a/bfvcheck
+++ b/bfvcheck
@@ -27,19 +27,25 @@
 # of the authors and should not be interpreted as representing official policies,
 # either expressed or implied, of the FreeBSD Project.
 
+PROGNAME=bfvcheck
+
+err () {
+    echo "$PROGNAME: $@" >&2
+}
+
 echo "Beginning version check..."
 
 # bfb file used to extract ATF/UEFI's expected version information
 BOOTIMG_LOCATION=/lib/firmware/mellanox/boot/default.bfb
 
-mlxfw=$(bfhcafw find)
+bfhcafw_status=0
+mlxfw=$(bfhcafw find) || bfhcafw_status=$?
 
-if [ "$?" -ne 0 ]; then
+if [ "$bfhcafw_status" -ne 0 ]; then
     # FW package not found anywhere, so error out fw check
     # We keep going to check bootloader versions anyway.
-    echo "The firmware package could not be located."
-    echo "Firmware check will fail."
-    echo ""
+    err "The firmware package could not be located."
+    err "Firmware check will fail."
     mlxfw=false
 fi
 
@@ -87,11 +93,12 @@ if [ $MLXFW_SUCCESS -eq 0 ]; then
         FW_UPDATED=yes
     fi
 else
-    echo "There was an error detecting the firmware version."
-    echo ""
+    err "There was an error detecting the firmware version."
     BUILD_FW=ERROR
     RUNTIME_FW=
 fi
+
+echo ""
 
 cat << EOF
 -RECOMMENDED VERSIONS-
@@ -111,7 +118,6 @@ EOF
 
 compare_versions "$BUILD_ATF" "$RUNTIME_ATF" "ATF"
 compare_versions "$BUILD_UEFI" "$RUNTIME_UEFI" "UEFI"
-compare_versions "$BUILD_FW" "$RUNTIME_FW" "FW"
 
 if [ "$FW_UPDATED" = "yes" ]; then
     cat << EOF
@@ -119,6 +125,18 @@ WARNING: The firmware has been updated, but the chassis must be
 power cycled for changes to take effect.
 
 EOF
+fi
+
+if [ "$BUILD_FW" = "N/A" ]; then
+    cat << EOF
+WARNING: The bundled firmware manager ($mlxfw)
+does not recognize the current card. No recommended firmware can
+be determined.
+
+EOF
+    version_error=ERR
+else
+    compare_versions "$BUILD_FW" "$RUNTIME_FW" "FW"
 fi
 
 echo "Version check complete."

--- a/bfvcheck
+++ b/bfvcheck
@@ -119,14 +119,6 @@ EOF
 compare_versions "$BUILD_ATF" "$RUNTIME_ATF" "ATF"
 compare_versions "$BUILD_UEFI" "$RUNTIME_UEFI" "UEFI"
 
-if [ "$FW_UPDATED" = "yes" ]; then
-    cat << EOF
-WARNING: The firmware has been updated, but the chassis must be
-power cycled for changes to take effect.
-
-EOF
-fi
-
 if [ "$BUILD_FW" = "N/A" ]; then
     cat << EOF
 WARNING: The bundled firmware manager ($mlxfw)
@@ -137,6 +129,14 @@ EOF
     version_error=ERR
 else
     compare_versions "$BUILD_FW" "$RUNTIME_FW" "FW"
+fi
+
+if [ "$FW_UPDATED" = "yes" ]; then
+    cat << EOF
+WARNING: The firmware has been updated, but the chassis must be
+power cycled for changes to take effect.
+
+EOF
 fi
 
 echo "Version check complete."


### PR DESCRIPTION
A previous fix broke bfhcafw's search mechanism for older distributions. Fix this. Also, add a more accurate error message for cases where recommended firmware cannot be determined.