### PR TITLE
add 'bfsbdump' to dump secure boot status information

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Overview of each file:
 - **bfpxe** PXE boot helper script.
 - **bfrec** Force update of the bootloader only.
 - **bfrshlog** Write message into the rshim logging buffer.
+- **bfsbdump** Dump secure boot status information.
 - **bfsbkeys** Dump all public keys in ATF.
 - **bfsbverify** Read BFB file from file or device and verify RoTPK and CoT.
 - **bfver** Print ATF, UEFI and rootfs versions.

--- a/bfsbdump
+++ b/bfsbdump
@@ -1,0 +1,134 @@
+#!/usr/bin/python3
+
+"""
+Dump BlueField secure boot status information.
+"""
+
+import argparse
+import struct
+import binascii
+import os
+import sys
+import subprocess
+
+LifeCycleState = [ 'Production', 'Secure', 'Non-Secure', 'RMA' ]
+
+DeviceIdTable = {
+    '0x00000211': 'BlueField1',
+    '0x00000214': 'BlueField2',
+    '0x0000021c': 'BlueField3'
+}
+
+def GetPlatformName():
+    Out = subprocess.run(['bfhcafw', 'mcra', '0xf0014.0:16'], stdout=subprocess.PIPE)
+    DeviceId = Out.stdout[:-1].decode('utf-8')
+    if DeviceId in DeviceIdTable:
+        return DeviceIdTable[DeviceId]
+    else:
+        print('Error! can not read device id', file=sys.stderr)
+        sys.exit (1)
+
+def CountSetBits(n):
+    return bin(n).count("1")
+
+class ChipSecureBootStatus:
+
+    def __init__(self):
+        self.PlatformName = GetPlatformName()
+
+    def Decode(self, data):
+        __StructFormat = '<I32sIHHBBBBB??B?15s'
+        __StructSize = struct.calcsize(__StructFormat)
+        if __StructSize != len(data):
+            print('Error! bad size {}, expected size {}'.format(__StructSize, len(data)), file=sys.stderr)
+            sys.exit (1)
+
+        '''
+        Defined C structure which encapsulates the BlueField Secure Boot
+        status information.
+
+        typedef struct {
+        UINT64  DotChipId[4];
+        UINT32  DotFsblVersion;
+        UINT16  DotMonotonicCounter;
+        UINT16  RevMonotonicCounter;
+        UINT8   TrustedBootFwNonVolatileCounter;
+        UINT8   UntrustedBootFwNonVolatileCounter;
+        UINT8   CerberusNonVolatileCounter;
+        UINT8   NvProductionStatus;
+        UINT8   LifeCycleStatus;
+        BOOLEAN SecureBootEnabled;
+        BOOLEAN SecureBootEnabledWithDevKey;
+        UINT8   SecureBootKeyStatus;
+        BOOLEAN CryptoEnabled;
+        UINT8   Reserved[15];
+        } CHIP_SECURE_BOOT_STATUS;
+        '''
+        (self.__hdr,
+            self.DotChipId,
+            self.DotFsblVersion,
+            self.DotMonotonicCounter,
+            self.RevMonotonicCounter,
+            self.TrustedBootFwNonVolatileCounter,
+            self.UntrustedBootFwNonVolatileCounter,
+            self.CerberusNonVolatileCounter,
+            self.NvProduction,
+            self.LifeCycle,
+            self.SecureBootEnabled,
+            self.SecureBootEnabledWithDevKey,
+            self.SecureBootKeyStatus,
+            self.CryptoEnabled,
+            self.Reserved) = struct.unpack(__StructFormat, data)
+    
+    def Dump(self):
+        if self.LifeCycle > 3:
+            print('Error! bad life cycle state {:02X}, expected {:02X}, {:02X}, {:02X}, or {:02X}'.format(
+                    self.LifeCycle, 0, 1, 2, 3 ), file=sys.stdout)
+            sys.exit(1)
+
+        print('')
+        print(' ' + self.PlatformName)
+        print('----------------------')
+        if self.PlatformName == 'BlueField3':
+            print('NV Production        : ' + str(self.NvProduction))
+        print('Arm Life Cycle       : ' + str(LifeCycleState[self.LifeCycle]))
+        print('Secure Boot          : Enabled' if self.SecureBootEnabled else
+              'Secure Boot          : Disabled')
+        if self.SecureBootEnabled:
+            print('Secure Boot Key      : Development' if self.SecureBootEnabledWithDevKey else
+                  'Secure Boot Key      : Production')
+            print('Secure Boot Key Valid: ' + str(CountSetBits((self.SecureBootKeyStatus >> 4) & 0xf)))
+            print('Secure Boot Key Count: ' + str(CountSetBits(self.SecureBootKeyStatus & 0xf)))
+        print('Crypto               : Enabled' if self.CryptoEnabled else 
+              'Crypto               : Disabled')
+        print('Trusted FW counter   : ' + str(self.TrustedBootFwNonVolatileCounter))
+        print('Untrusted FW counter : ' + str(self.UntrustedBootFwNonVolatileCounter))
+        if self.PlatformName == 'BlueField2':
+            print('Cerberus counter     : ' + str(self.CerberusNonVolatileCounter))
+        if self.PlatformName != 'BlueField1' :
+            print('REVMC                : ' + str(self.RevMonotonicCounter))
+            print('DOTMC                : ' + str(self.DotMonotonicCounter))
+            print('DOT FSBL Version     : {a}.{b}.{c}.{d}'.format (
+                a = (self.DotFsblVersion >>  0) & 0xFF, b = (self.DotFsblVersion >>  8) & 0xFF,
+                c = (self.DotFsblVersion >> 16) & 0xFF, d = (self.DotFsblVersion >> 24) & 0xFF ))
+        print('DOT ID               : ' + str(binascii.hexlify(self.DotChipId).decode('ascii')))
+        print('----------------------')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Dump BlueField platform secure boot status information.")
+    options = parser.parse_args()
+
+    EfiVar="/sys/firmware/efi/efivars/BfSbStatus-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+    if os.path.exists(EfiVar):
+        with open(EfiVar, "rb") as var:
+            Data = var.read()
+
+        Sb = ChipSecureBootStatus()
+        Sb.Decode(Data)
+        Sb.Dump()
+    
+    else:
+        print('Error! cannot find EFI variable', file=sys.stderr)
+        sys.exit(1)
+

--- a/debian/mlxbf-scripts.install
+++ b/debian/mlxbf-scripts.install
@@ -1,4 +1,4 @@
 bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst usr/bin/
-bfpart bfpxe bfrec bfrshlog bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
+bfpart bfpxe bfrec bfrshlog bfsbdump bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
 bfvcheck.service lib/systemd/system/
 mlx-uefi.quirk usr/share/fwupd/quirks.d/

--- a/man/bfsbdump.8
+++ b/man/bfsbdump.8
@@ -1,0 +1,11 @@
+.TH BFSBDUMP 8 "February 2023"
+.SH NAME
+bfsbdump \- Dump secure boot status information
+.SH SYNOPSIS
+.B bfsbdump
+.RB [ \-\-help | \-h ]
+.SH DESCRIPTION
+Dump BlueField platform secure boot status information.
+.SH OPTIONS
+.IP "-h|--help"
+Print help.

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -67,6 +67,8 @@ install -p bfrec             %{installdir}
 install -p man/bfrec.8       %{man8dir}
 install -p bfrshlog          %{installdir}
 install -p man/bfrshlog.8    %{man8dir}
+install -p bfsbdump          %{installdir}
+install -p man/bfsbdump.8    %{man8dir}
 install -p bfsbkeys          %{installdir}
 install -p man/bfsbkeys.8    %{man8dir}
 install -p bfsbverify        %{installdir}

--- a/mlxbf-bfscripts.spec.rpkg
+++ b/mlxbf-bfscripts.spec.rpkg
@@ -70,6 +70,8 @@ install -p bfpxe             %{installdir}
 install -p man/bfpxe.8       %{man8dir}
 install -p bfrec             %{installdir}
 install -p man/bfrec.8       %{man8dir}
+install -p bfsbdump          %{installdir}
+install -p man/bfsbdump.8    %{man8dir}
 install -p bfsbkeys          %{installdir}
 install -p man/bfsbkeys.8    %{man8dir}
 install -p bfsbverify        %{installdir}


### PR DESCRIPTION
This script relies on 'BfSbStatus' EFI variable to read and print information about the life cycle, the crypto config, the secure boot, non volatile counters and other DOT info.

RM #3353907