### PR TITLE
bffamily: Find OPN from lspci instead of mlxvpd

### DIFF
--- a/bffamily
+++ b/bffamily
@@ -81,7 +81,7 @@ elif [ "$bfversion" = $BF3_PLATFORM_ID ]; then
 	["Goldeneye"]="900-9D3D4-00(EN|NN)-(GA|HA)(0|A|B)"
 	["Roy"]="699-21014-0230"
     )
-    PART_NUMBER=$(mlxvpd -d /dev/mst/mt41692_pciconf0 | grep "Part Number" | awk '{print $NF}')
+    PART_NUMBER=$(lspci -s "$(bfhcafw bus)" -vv | grep PN)
 
 else
     echo "Unknown platform"


### PR DESCRIPTION
The Oracle BFBs do not seem to have MST included, hence there is no /dev/mst which is currently used by mlxvpd. Instead, use lspci to read the PN similar to BlueField-1.