### PR TITLE
Support setting ARM boot state to OS up in GPIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Overview of each file:
 - **bfvcheck** Check whether software versions installed match those in current release.
 - **bfvcheck.service** Companion service to bfvcheck, runs bfvcheck at boot time.
 - **mlx-mkbfb** Builds and extracts BFB files.
+- **bfup** Informs that linux is running via rshlog message and gpio pin

--- a/bfstart
+++ b/bfstart
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (c) 2023, Mellanox Technologies
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+/usr/bin/bfrshlog "Linux up"
+
+os_up_path="/sys/devices/platform/MLNXBF04:00/driver/os_up"
+if [ ! -e "${os_up_path}" ]; then
+  os_up_path="/sys/devices/platform/MLNXBF04:00/os_up"
+fi
+
+[ ! -e "${os_up_path}" ] && exit
+
+echo 1 > "${os_up_path}"

--- a/bfvcheck.service
+++ b/bfvcheck.service
@@ -4,7 +4,7 @@ After=getty.target
 
 [Service]
 Type=idle
-ExecStartPre=/usr/bin/bfrshlog "Linux up"
+ExecStartPre=/usr/bin/bfup
 ExecStart=/usr/bin/bfvcheck
 StandardOutput=journal+console
 

--- a/debian/mlxbf-scripts.install
+++ b/debian/mlxbf-scripts.install
@@ -1,4 +1,4 @@
-bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst usr/bin/
+bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst bfup usr/bin/
 bfpart bfpxe bfrec bfrshlog bfsbdump bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
 bfvcheck.service lib/systemd/system/
 mlx-uefi.quirk usr/share/fwupd/quirks.d/

--- a/man/bfstart.8
+++ b/man/bfstart.8
@@ -1,0 +1,10 @@
+.TH BFSTART 28 "March 2023"
+.SH NAME
+bfup \- Signals that linux is up via rshlog and gpio pins.
+.SH SYNOPSIS
+.B bfup
+.SH DESCRIPTION
+Signals that linux is up via rshlog and gpio pins.
+.SH OPTIONS
+.B bfup
+takes no options.

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -83,6 +83,8 @@ install -p bfgrubcheck       %{installdir}
 install -p man/bfgrubcheck.8 %{man8dir}
 install -p bfhcafw           %{installdir}
 install -p man/bfhcafw.8     %{man8dir}
+install -p bfup              %{installdir}
+install -p man/bfup.8        %{man8dir}
 
 install -p mlx-mkbfb       %{installdir}
 install -p man/mlx-mkbfb.1 %{man1dir}

--- a/mlxbf-bfscripts.spec.rpkg
+++ b/mlxbf-bfscripts.spec.rpkg
@@ -88,6 +88,8 @@ install -p bfhcafw           %{installdir}
 install -p man/bfhcafw.8     %{man8dir}
 install -p bfrshlog          %{installdir}
 install -p man/bfrshlog.8    %{man8dir}
+install -p bfup              %{installdir}
+install -p man/bfup.8        %{man8dir}
 
 install -p mlx-mkbfb       %{installdir}
 install -p man/mlx-mkbfb.1 %{man1dir}


### PR DESCRIPTION
ARM needs to indicate that linux is up to the NIC via fw_gpio[16] for the following reasons:
1) mlxfwreset sync 1 to initiate full chip reset on BF3. When the system is in low power state (due to panic for example), the NIC needs an indicator to trigger the DPU reset.
2) Some customers such as Baidu and CTC also might need this indicator since their x86 host boots much faster than the DPU. Their x86 host however, needs to wait for the DPU to be fully booted due to its dependency on virtio. This design has not been approved yet but it is something to take into account.

Setting the ARM boot state in gpio-mlxbf2.c and gpio-mlxbf3.c is not a good solution because:
- it will unlikely be accepted by the upstream community
- it will allow userspace to have access to the concerned GPIOs via sysfs

Instead, we will use the same strategy as for rshlog i.e. create an SMC call to only allow the user to set the arm boot state to "OS is up". The mlx-bootctl will allow userspace to issue that request to ATF via a sysfs entry: echo 1 > /sys/devices/platform/MLNXBF04:00/driver/os_up This way, userspace is restricted to setting the arm boot state = os is up. Then bfvcheck.service will make the SMC call to set the state.

RM #3410286