### PR TITLE
bfrec: add checking for python3

### DIFF
--- a/bfrec
+++ b/bfrec
@@ -245,8 +245,14 @@ verify_bfb_signature()
     in_bfb=$1
     in_ver=$2
 
-    if [ ! "$(which openssl)" ]; then
+    if [ ! "$(which openssl 2>/dev/null)" ]; then
         echo "cannot find \"openssl\" command!"
+        echo "skip BFB signature verification"
+        return 0
+    fi
+
+    if [ ! "$(which python3 2>/dev/null)" ]; then
+        echo "cannot find \"python3\" command!"
         echo "skip BFB signature verification"
         return 0
     fi


### PR DESCRIPTION
This fix adds checking for python3 to avoid failure in bfsbverify.

RM #3457900