### PR TITLE
bfrec: use 'blkid' instead of 'fdisk' to display ESP devices

### DIFF
--- a/bfrec
+++ b/bfrec
@@ -180,7 +180,7 @@ uefi_capsule_update()
     # partition to the default location in order to copy the update
     # files. It is harmless to copy the files to multiple EFI System
     # partitions.
-    device_efi=$(fdisk -l | grep -i EFI | cut -d' ' -f1 | tr '\n' ' ')
+    device_efi=$(blkid | grep -i -e 'system-boot' -e 'efi' | cut -d':' -f1 | tr '\n' ' ')
     for curr_device_efi in $device_efi
     do
         # Set EFI System partition mountpoint


### PR DESCRIPTION
Old versions of 'fdisk' don't display the device full name of the EFI System Partition thus the output cannot be parsed given the current logic. Thus substitute 'fdisk' command with 'blkid'. The block devices listed by 'blkid' are filtered out using the LABEL field. It is expected that EFI System Partition would show either "system-boot" or "EFI*".

These changes implemented in 'bfrec' should be compatible accross distirbutions.

RM #3693653