### PR TITLE
Add script to print DDR training parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Overview of each file:
 - **bfsbdump** Dump secure boot status information.
 - **bfsbkeys** Dump all public keys in ATF.
 - **bfsbverify** Read BFB file from file or device and verify RoTPK and CoT.
+- **bftraining_results** Read DDR5 training parameters from ACPI.
 - **bfver** Print ATF, UEFI and rootfs versions.
 - **bfvcheck** Check whether software versions installed match those in current release.
 - **bfvcheck.service** Companion service to bfvcheck, runs bfvcheck at boot time.

--- a/bftraining_results
+++ b/bftraining_results
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 NVIDIA Corporation.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+"""
+Print BlueField DDR memory training results.
+"""
+
+import array
+import re
+
+hidtag=bytearray('MLNXBF3B', encoding='ascii')
+uidtag=bytearray('_UID', encoding='ascii')
+properties=[('read-timing-margin', 'Read Data worst timing margin'),
+            ('write-timing-margin', 'Write Data worst timing margin'),
+            ('read-vref-margin', 'Read Data worst Vref margin'),
+            ('write-vref-margin', 'Write Data worst Vref margin'),
+            ('cs-vref-margin', 'TX CS worst Vref margin'),
+            ('ca-vref-margin', 'TX CA worst Vref margin'),
+            ('cs-timing-margin', 'TX CS worst timing margin'),
+            ('ca-timing-margin', 'TX CA worst timing margin')]
+            
+def get_byte_value(table, property):
+    pos = table.find(property, 0)
+    pos += len(property)
+    return table[pos+2]
+
+def get_bool_value(table, property):
+    pos = table.find(property, 0)
+    pos += len(property)
+    if table[pos] == 0xa:
+        pos += 1
+    return table[pos]
+
+with open(r"/sys/firmware/acpi/tables/SSDT1", "rb") as ssdt1:
+    contents = ssdt1.read()
+    strings = contents.decode('ascii', errors='ignore')
+
+    ddr_pos = contents.find(hidtag, 0)
+    while ddr_pos != -1:
+        contents = contents[ddr_pos:]
+        uid = get_bool_value(contents, uidtag)
+        print("Memory controller %d Channel %d " % (uid >> 1, uid & 1))
+        if get_byte_value(contents, bytearray('populated', encoding='ascii')) == 1:
+            for p in properties:
+                val = get_byte_value(contents, bytearray(p[0], encoding='ascii'))
+                if val > 0:
+                    print(p[1], val)
+        else:
+            print("Unpopulated")
+        
+        ddr_pos = contents.find(hidtag, 1)
+        print()

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,4 @@
-bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst bfup usr/bin/
+bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst bfup bftraining_results usr/bin/
 bfpart bfpxe bfrec bfrshlog bfsbdump bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
 bfvcheck.service bfup.service lib/systemd/system/
 mlx-uefi.quirk usr/share/fwupd/quirks.d/

--- a/man/bftraining_results.8
+++ b/man/bftraining_results.8
@@ -1,0 +1,13 @@
+.TH BFTRAINING_RESULTS 8 "December 2023"
+.SH NAME
+bftraining_results \- Print DDR5 training parameters
+.SH SYNOPSIS
+.B bftraining_results
+.SH DESCRIPTION
+
+On platforms with DDR5 DRAM, print the training parameter results. Results
+are reported seperately for each memory channel.  On platforms with DDR4,
+no results are printed.
+.SH OPTIONS
+.B bftraining_results
+accepts no options.

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -86,9 +86,10 @@ install -p bfhcafw           %{installdir}
 install -p man/bfhcafw.8     %{man8dir}
 install -p bfup              %{installdir}
 install -p man/bfup.8        %{man8dir}
-
 install -p mlx-mkbfb       %{installdir}
 install -p man/mlx-mkbfb.1 %{man1dir}
+install -p bftraining_results %{installdir}
+install -p man/bftraining_results.8 %{man8dir}
 
 install -p -d %{buildroot}%{_unitdir}
 install -p bfvcheck.service %{buildroot}%{_unitdir}/


### PR DESCRIPTION
Look for devices with HID MLNXBF3B in the SSDT and extract the DDR5 training results.  There should be one device entry for each of the four possible DDR channels.

RM #3693559