### PR TITLE
bfup: Adding "DPU is ready" to the rshim log

### DIFF
--- a/bfup
+++ b/bfup
@@ -28,6 +28,7 @@
 # either expressed or implied, of the FreeBSD Project.
 
 /usr/bin/bfrshlog "Linux up"
+/usr/bin/bfrshlog "DPU is ready"
 
 os_up_path="/sys/devices/platform/MLNXBF04:00/driver/os_up"
 if [ ! -e "${os_up_path}" ]; then


### PR DESCRIPTION
This is required for the older versions of the bfb-install script to exit when the BFB installation finished and the DPU is up after the first boot. Without this bfb-install will not finish.