### PR TITLE
bfsbverify: create temporary folder per user

### DIFF
--- a/bfsbverify
+++ b/bfsbverify
@@ -62,8 +62,10 @@ mlxbfbootctl=${BFBOOTCTL_PATH:-mlxbf-bootctl}
 debug=${DEBUG_ENABLE:-}
 
 scratch=${SCRATCH_PATH:-/tmp}
-# Indirection to protect against "rm -fr /" mistakes.
-tmpdir=$scratch/bfbtmp
+tmpdir=$(mktemp -d $scratch/bfbtmp-${USER}.XXXXXXXXXXXX)
+# Trap to delete the temorary folder upon the specified
+# signal is caught.
+trap "rm -rf $tmpdir" SIGHUP SIGINT SIGQUIT SIGABRT SIGTERM SIGKILL SIGSTOP
 
 
 ##############################################################################


### PR DESCRIPTION
The 'bfsbverify' command relies on a common temporary folder under /tmp/bfbtmp; when user A executes the command and the temporary folder is left undeleted (because of a failure or because the command execution is interrupted), then user B would fail to execute the command because the bfsbverify won't have the permissions to cleanup the temp directory initially created by user A. Thus address the issue by creating separate temporary foders per user context.

RM #3766115