### PR TITLE
bfver: cleanup temp files in print_bfb_file_vers()

### DIFF
--- a/bfver
+++ b/bfver
@@ -112,7 +112,7 @@ print_bfb_file_vers () {
     # for version strings
     UEFI_IMAGE="$BFB_PATH"
     if [ -z "$UEFI_VER" ]; then
-      mkdir "$TMP_DIR"/uefi
+      mkdir -p "$TMP_DIR"/uefi
       cd "$TMP_DIR"/uefi
       mlx-mkbfb -x "$BFB_PATH"
       gzipped=$(file dump-bl33-v0 | grep gzip)
@@ -134,6 +134,11 @@ print_bfb_file_vers () {
     # Essentially, match the string as Major.Minor.Patch in front,
     # the git describe tag from the back, and anything in the middle.
     BSP_MAJOR_MINOR_PATCH="$(echo "$UEFI_VER" | sed 's/\(.\+\..\+\..\+\).*-[0-9]\+-g[0-9a-fA-F]\+/\1/')"
+
+    # cleanup temp files if needed.
+    if [ -z "$UEFI_VER" ]; then
+      rm -rf "$TMP_DIR"/uefi
+    fi
 
     # Find build ID
     BUILD_ID="$(strings -el "$UEFI_IMAGE" | grep "BId" | sed "s/^BId//")"


### PR DESCRIPTION
When '-p0,1' is specified in 'bfver' command line the version is read from both boot partitions. Thus, print_path_vers() is called against the primary and secondary boot partitions. As a result, print_bfb_file_vers() is called twice and fail to create the temp folder because it already exists, i.e., previously created during the first call. To address the issue, cleanup the temp files at the end of print_bfb_file_vers() routine, so that next call won't fail to create the temp folder.