### PR TITLE
bfsbverify: omit 'SIG' prefix from signals listed in 'trap' command line

### DIFF
--- a/bfsbverify
+++ b/bfsbverify
@@ -65,7 +65,7 @@ scratch=${SCRATCH_PATH:-/tmp}
 tmpdir=$(mktemp -d $scratch/bfbtmp-${USER}.XXXXXXXXXXXX)
 # Trap to delete the temorary folder upon the specified
 # signal is caught.
-trap "rm -rf $tmpdir" SIGHUP SIGINT SIGQUIT SIGABRT SIGTERM SIGKILL SIGSTOP
+trap "rm -rf $tmpdir" HUP INT QUIT ABRT TERM KILL STOP
 
 
 ##############################################################################


### PR DESCRIPTION
The error "trap: SIGHUP: bad trap" is returned when 'bfsbverify' command is executed on Ubuntu shell; 'sh' is being linked to 'dash' and the 'SIG' prefix causes an error when executing 'trap' command line. Thus omit the prefix 'SIG' from signals listed in the 'trap' command line.