### PR TITLE
Add warning logs to notify script deprecation

### DIFF
--- a/bfacpievt
+++ b/bfacpievt
@@ -29,6 +29,8 @@
 
 # This feature is supported only on OCP 3.0 cards
 
+echo "WARNING: This script is no longer supported and will eventually be removed."
+
 usage()
 {
   cat <<EOF

--- a/bfdracut
+++ b/bfdracut
@@ -37,6 +37,8 @@ set -e
 # in IB mode.
 #
 
+echo "WARNING: This script is no longer supported and will eventually be removed."
+
 PROGNAME=$(basename "$0")
 # Check arguments. For now, only output initramfs image is expected.
 # if the output image argument is ommitted, then the default location

--- a/bfinst
+++ b/bfinst
@@ -37,6 +37,8 @@ EOF
 
 ECHO=${ECHO:-echo}
 
+${ECHO} "WARNING: This script is no longer supported and will eventually be removed."
+
 PARSED_OPTIONS=$(getopt -n "$0" -o h \
     --long "help unloadmods minifs fullfs fmtpersist persistcfg skip-boot-update" -- "$@")
 


### PR DESCRIPTION
The following scripts are deprecated and will no longer be supported:
- bfinst
- bfdracut
- bfacpievt

These scripts will eventually be removed so logs have been added to warn users in advance. Verified by running scripts and making sure warning log is visible first.

RM #3830034