### PR TITLE
Add Zhora OPN to bffamily

### DIFF
--- a/bffamily
+++ b/bffamily
@@ -80,6 +80,7 @@ elif [ "$bfversion" = $BF3_PLATFORM_ID ]; then
 	["Moonraker"]="(900-9D3(B|C)|SN37B36732|SN37B75411|8217991|P66102)"
 	["Goldeneye"]="(900-9D3D|P66584)"
 	["Roy"]="699-21014-0230"
+	["Zhora"]="800-11012-0000-000"
     )
     PART_NUMBER=$(lspci -s "$(bfhcafw bus)" -vv | grep PN)
 


### PR DESCRIPTION
Add Zhora as a new family type because of its unique OPN and configuration.

RM #3821681