### PR TITLE
Reserve image id for runtime upgrade

### DIFF
--- a/bfrec
+++ b/bfrec
@@ -107,7 +107,7 @@ fi
 # Only allow capsule when secure boot is enabled.
 if [ -n "$bootctl_mode" ]; then
     if [ -n "$secure_boot" ]; then
-        echo "ERROR: need to use capsule in secure boot mode" >&2
+        echo "ERROR: need to use capsule when UEFI secure boot PK key is enrolled" >&2
         exit 1
     fi
 

--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -557,7 +557,7 @@ def make_stream(infnt, outfn, image_tuples, expert):
     outfile.close()
 
 
-def dump_stream(infn, do_dump, do_extract, prefix):
+def dump_stream(infn, do_dump, do_extract, prefix, images):
     """
     Dump a description of a boot stream.
 
@@ -594,9 +594,10 @@ def dump_stream(infn, do_dump, do_extract, prefix):
                 print("%10d %s" % (img.get_image_length(), desc))
 
         if do_extract:
-            xfile = open(prefix + fn, "wb")
-            xfile.write(img.get_bits())
-            xfile.close()
+            if not images or fn in images.split():
+                xfile = open(prefix + fn, "wb")
+                xfile.write(img.get_bits())
+                xfile.close()
 
     inf.close()
 
@@ -750,6 +751,10 @@ def main(argv):
             "-x", "--extract", dest="x", action="store_true",
             help="extract images from INFILE and write to files")
     parser.add_option(
+            "-n", "--image-name", dest="n", action="store", type="string",
+            metavar="INM", default="",
+            help="a string with image names (separated by space) to extract,  (used with -x option); ")
+    parser.add_option(
             "-p", "--prefix", dest="p", action="store", type="string",
             metavar="PFX", default="dump-",
             help="prefix for files containing extracted images; "
@@ -821,7 +826,7 @@ def main(argv):
             parser.error("cannot specify images with -d/-x/-s")
 
     if opt.d or opt.x:
-        dump_stream(args[0], opt.d, opt.x, opt.p)
+        dump_stream(args[0], opt.d, opt.x, opt.p, opt.n)
     elif opt.f is not None:
         if len(args) != 2:
             parser.error("--filter/-f: must specify exactly one input file and "

--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -98,6 +98,7 @@ image_list = (
     ("ramdisk", "RAM Disk image", 54),
     ("image", "Boot image", 62),
     ("initramfs", "In-memory filesystem", 63),
+    ("upgrade-image", "Runtime upgrade image", 51),
 )
 
 # Map command-line option to (description, image ID)


### PR DESCRIPTION
In NIC mode, a bfb image could be pushed for runtime upgrade. This BFB contains Image, Initramfs and the upgrade image, while Image/Initramfs are used by NIC mode to boot into Linux and the upgrade image are used by both NIC mode and DPU mode for upgrade, thus it needs to be the last image.

RM #3936308