### PR TITLE
Parse out unintended bytes in build ID string

### DIFF
--- a/bfver
+++ b/bfver
@@ -140,8 +140,10 @@ print_bfb_file_vers () {
       rm -rf "$TMP_DIR"/uefi
     fi
 
-    # Find build ID
-    BUILD_ID="$(strings -el "$UEFI_IMAGE" | grep "BId" | sed "s/^BId//")"
+    # Find build ID. Note that when locating strings in the UEFI_IMAGE binary it's possible that
+    # the BId string can contain extra characters before and after the build ID that need to be
+    # cut out. This sed regex takes only the numbers directly following "BId".
+    BUILD_ID="$(strings -el "$UEFI_IMAGE" | grep "BId" | sed "s/.*BId\([0-9]*\).*/\1/")"
 
     if [ -z "$BUILD_ID" ]; then
         echo "$PROGNAME: warn: could not find UEFI build ID (likely bootloader too old, using placeholder value)" >&2


### PR DESCRIPTION
Recent changes to our bl33 binary have resulted in some data
getting rearranged in the binary's data section. The bfver script
uses the Linux "strings" utility to parse the "BId" string from the
raw binary and, depending on the data that is next to that string in the
binary, can sometimes include unexpected bytes as part of the
located string.

For example, the following shows how there is an "a" character
prepended before the expected build ID string:
```
root@bu-lab102:~/cbabroski/tmp# strings -el dump-bl33-v0
aBId13164
...
```
And this results in the BSP version displayed by bfver to have a
corrupted build ID:
```
svc-soc-ver@bu-lab40v-oob:~$ sudo bfver
...
BlueField BSP version: 4.8.0.aBId13156
```
The fix is to update the sed regex used to cut out the build ID number
which should never contain letters or special characters. The new regex
will cut out all characters before and after the actual build ID number.

Note that using "strings" to search for these versions in the binary is prone to errors. In the future we may want to put these values in an EFI variable that bfver can read instead.

RM #3948954