### PR TITLE
Update search method for platform type

### DIFF
--- a/bfhcafw
+++ b/bfhcafw
@@ -78,13 +78,13 @@ get_chipnum () {
     fi
 
     # Figure out which rev by searching for an ACPI table specific to the BF version
-    if hexdump -C /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF02; then
+    if strings /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF02; then
         # BF1
         chipnum=41682
-    elif hexdump -C /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF22; then
+    elif strings /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF22; then
         # BF2
         chipnum=41686
-    elif hexdump -C /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF33; then
+    elif strings /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF33; then
         # BF3
         chipnum=41692
     fi

--- a/bfrec
+++ b/bfrec
@@ -304,13 +304,13 @@ kernel_bootctl_update()
     # Figure out te platform by searching for an ACPI table
     # specific to the BF version (ACPI trick to learn about
     # the platform version) and verify BFB signature,
-    # if needed. BFB sinature verification is ignored in
+    # if needed. BFB signature verification is ignored in
     # BlueField-1 devices.
     if [ -e /sys/firmware/acpi/tables ]; then
-        if hexdump -C /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF22; then
+        if strings /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF22; then
             # Verify BFB for BlueField-2 device.
             verify_bfb_signature $bfb_file 1
-        elif hexdump -C /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF33; then
+        elif strings /sys/firmware/acpi/tables/SSDT* | grep -q MLNXBF33; then
             # Verify BFB for BlueField-3 device.
             verify_bfb_signature $bfb_file 2
         fi

--- a/bfsbdump
+++ b/bfsbdump
@@ -40,11 +40,11 @@ LifeCycleState = [ 'Production', 'Secure', 'Non-Secure', 'RMA' ]
 
 # Figure out which platform searching for an ACPI table specific to the BF version
 def GetPlatformName():
-    if os.popen('hexdump -C /sys/firmware/acpi/tables/SSDT* | grep MLNXBF02').read():
+    if os.popen('strings /sys/firmware/acpi/tables/SSDT* | grep MLNXBF02').read():
         return 'BlueField1'
-    elif os.popen('hexdump -C /sys/firmware/acpi/tables/SSDT* | grep MLNXBF22').read():
+    elif os.popen('strings /sys/firmware/acpi/tables/SSDT* | grep MLNXBF22').read():
         return 'BlueField2'
-    elif os.popen('hexdump -C /sys/firmware/acpi/tables/SSDT* | grep MLNXBF33').read():
+    elif os.popen('strings /sys/firmware/acpi/tables/SSDT* | grep MLNXBF33').read():
         return 'BlueField3'
     else:
         print('Error! can not read platform name', file=sys.stderr)


### PR DESCRIPTION
Platform type is found by parsing through SSDT tables for respective strings. Using hexdump utility is prone to be ineffective as SSDT tables are updated over time and the string is not placed on the same line for grep utility to succeed. For example, below is the output from hexdump and we can observe "MLNXBF33" string is spread over two lines and therefore grep will fail: 

   |.M.GPI1._HID.MLN| 
   |XBF33.._UID.._CC|




RM #3951579