### PR TITLE
mlx-mkbfb: Add "info" field for components version tracking

### DIFF
--- a/mlx-mkbfb
+++ b/mlx-mkbfb
@@ -96,6 +96,7 @@ image_list = (
     ("uefi-tests", "Specify what UEFI tests to run", 61),
     ("dummy", "Dummy data for padding", 41),
     ("ramdisk", "RAM Disk image", 54),
+    ("info", "BFB versioning information", 50),
     ("image", "Boot image", 62),
     ("initramfs", "In-memory filesystem", 63),
     ("upgrade-image", "Runtime upgrade image", 51),


### PR DESCRIPTION
Implement an "info" field in mlx-mkbfb to include a dump-info-v0 file in the BFB. This file contains version information for various BFB components, enabling easier tracking and verification of BFB contents

RM #4247297