### PR TITLE
Handle non-root users more gracefully

### DIFF
--- a/bfhcafw
+++ b/bfhcafw
@@ -135,6 +135,13 @@ find_fw_with_basename () {
 }
 
 find_fw () {
+    UID=$(id -u)
+
+    if [ "$UID" -ne 0 ]; then
+        err "fatal: must be root to find firmware"
+        exit 1
+    fi
+
     # First search using new filename, with the _fw suffix.
     fw_path="$(find_fw_with_basename ${BASE_FW_NAME}_fw)"
     if [ $? -eq 0 ]; then echo $fw_path; return 0; fi

--- a/bfver
+++ b/bfver
@@ -57,6 +57,10 @@ Options:
 EOF
 }
 
+err () {
+    echo "$PROGNAME: $@" >&2
+}
+
 print_path_vers () {
     # Print the versions of an image at a given path.
     # For any file, the versions contained in the BFB will be printed.
@@ -68,9 +72,9 @@ print_path_vers () {
         /dev/mmcblk0boot*) print_bfb_installed_vers "$STREAM_PATH";;
         *)
             if ! [ -e $STREAM_PATH ]; then
-                echo "$PROGNAME: warn: $STREAM_PATH does not exist, skipping" >&2
+                err "warn: $STREAM_PATH does not exist, skipping"
             elif ! [ -f $STREAM_PATH ]; then
-                echo "$PROGNAME: warn: $STREAM_PATH is not file, skipping" >&2
+                err "warn: $STREAM_PATH is not file, skipping"
             else
                 print_bfb_file_vers "$STREAM_PATH"
             fi
@@ -146,12 +150,12 @@ print_bfb_file_vers () {
     BUILD_ID="$(strings -el "$UEFI_IMAGE" | grep "BId" | sed "s/.*BId\([0-9]*\).*/\1/")"
 
     if [ -z "$BUILD_ID" ]; then
-        echo "$PROGNAME: warn: could not find UEFI build ID (likely bootloader too old, using placeholder value)" >&2
+        err "warn: could not find UEFI build ID (likely bootloader too old, using placeholder value)"
         BUILD_ID="$DEFAULT_BUILD_ID"
     fi
 
     if [ "$BUILD_ID" = 0 ]; then
-        echo "$PROGNAME: warn: build id of 0 (likely development image)" >&2
+        err "warn: build id of 0 (likely development image)"
     fi
 
     echo BlueField BSP version: ${BSP_MAJOR_MINOR_PATCH}.$BUILD_ID
@@ -188,10 +192,22 @@ do
 done
 
 if [ -n "$FILE" ]; then
+    if [ ! -r $FILE ]; then
+        err "fatal: $FILE does not exist or is not readable by the current user"
+        exit 1
+    fi
+
     print_path_vers $FILE
 
     # File mode, do not print any installation info
     exit 0
+fi
+
+UID=$(id -u)
+
+if [ "$UID" -ne 0 ]; then
+    err "fatal: must be run as root to check currently installed software"
+    exit 1
 fi
 
 # Print bootloader versions
@@ -201,7 +217,7 @@ if [ -z "$PARTLIST" ]; then
 else
     for part in $(echo $PARTLIST | cut -d"," -f1- --output-delimiter=" "); do
         if [ "$part" -ne 0 ] && [ "$part" -ne 1 ]; then
-            echo "$PROGNAME: err: bad partition $part" >&2
+            err "err: bad partition $part"
             continue
         fi
 


### PR DESCRIPTION
The bfver and bfhcafw scripts require root privileges for certain parts of their functionalities, but the scripts do not check/enforce this. If a user tries to execute those parts of the script as a non-root user, they get an excessive amount of permission error logs that clutter the output.

This commit more gracefully handles these scenarios by adding user or permission checks for commands that do not fail quickly/gracefully.

This commit also slightly refactors bfver to use a similar err function to bfhcafw and bfvcheck for better consistency and readability.

RM #4370524