### PR TITLE
Fix "UID: readonly variable" error

### DIFF
--- a/bfhcafw
+++ b/bfhcafw
@@ -135,9 +135,9 @@ find_fw_with_basename () {
 }
 
 find_fw () {
-    UID=$(id -u)
+    m_uid=$(id -u)
 
-    if [ "$UID" -ne 0 ]; then
+    if [ "$m_uid" -ne 0 ]; then
         err "fatal: must be root to find firmware"
         exit 1
     fi

--- a/bfver
+++ b/bfver
@@ -203,9 +203,9 @@ if [ -n "$FILE" ]; then
     exit 0
 fi
 
-UID=$(id -u)
+m_uid=$(id -u)
 
-if [ "$UID" -ne 0 ]; then
+if [ "$m_uid" -ne 0 ]; then
     err "fatal: must be run as root to check currently installed software"
     exit 1
 fi


### PR DESCRIPTION
Commit e197cd7 added checks against the current ID to fail more gracefully for non-root users. It attempts to set the "UID" variable while checking, which is only valid in some shells - in others, "UID" is a readonly variable.

This commit changes the variable being set to "m_uid" to remove the possibility of conflicts with system variables while remaining compatibility across all POSIX-compliant shells.

RM #4395696