### PR TITLE
Add support to parse ATF/UEFI version from capsule file, and transfer to UEFI.

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -53,6 +53,7 @@ mlxmkcap=/lib/firmware/mellanox/boot/capsule/scripts/mlx-mkcap
 
 bfcf_acpi_table=/sys/firmware/acpi/tables/BFCF
 efivars=/sys/firmware/efi/efivars
+efi_debug_var_guid=f3ce977e-c17f-493e-a3cd-5731d386e505
 sys_cfg_sysfs=${efivars}/BfSysCfg-9c759c02-e5a3-45e4-acfc-c34a500628a6
 redfish_cfg_sysfs=${efivars}/BfRedfish-ce3e5882-6770-4d5e-aa45-90f909da2446
 redfish_state_cfg_sysfs=${efivars}/BfRedfishState-ce3e5882-6770-4d5e-aa45-90f909da2446
@@ -67,6 +68,8 @@ bf_bundle_version_sysfs=${efivars}/BfBundleVer-${efi_bfcfg_var_guid}
 sb_custom_mode_sysfs=${efivars}/BfCfgSbCustomMode-${efi_bfcfg_var_guid}
 pass_settings_sysfs=${efivars}/BfCfgPassSettings-${efi_bfcfg_var_guid}
 bf_modes_sysfs=${efivars}/BfCfgBfModes-${efi_bfcfg_var_guid}
+cap_atf_version_sysfs=${efivars}/BfCapAtfVer-${efi_debug_var_guid}
+cap_uefi_version_sysfs=${efivars}/BfCapUefiVer-${efi_debug_var_guid}
 
 mfg_sysfs_dir=/sys/bus/platform/devices/MLNXBF04:00/driver
 if [ ! -e $mfg_sysfs_dir/oob_mac ]; then
@@ -3191,10 +3194,34 @@ print_osarg()
   fi
 }
 
+#
+# Pass the ATF version from capsule to UEFI variable.
+#
+set_cap_atf_version()
+{
+  printf "\\x06\\x00\\x00\\x00" > ${tmpdir}/cap_atf_version
+  echo "$1" >> ${tmpdir}/cap_atf_version
+
+  cp ${tmpdir}/cap_atf_version "${cap_atf_version_sysfs}" 2>/dev/null
+}
+
+#
+# Pass the UEFI version from capsule to UEFI variable.
+#
+set_cap_uefi_version()
+{
+  printf "\\x06\\x00\\x00\\x00" > ${tmpdir}/cap_uefi_version
+  echo "$1" >> ${tmpdir}/cap_uefi_version
+
+  cp ${tmpdir}/cap_uefi_version "${cap_uefi_version_sysfs}" 2>/dev/null
+}
+
 usage()
 {
   echo "syntax: bfcfg [--help|-h] [--version|-v] [--dump|-d] [--dump-level|-l <${DUMP_LEVEL_NONE}-${DUMP_LEVEL_MAX}>] [--dump-osarg|o]"
   echo "              [--part-info|-p] [--hscv|-h] [--cfg2bin|-c <cfg_file>] [--bin2cfg|-b <bin_file> [--skip-mfg]]"
+  echo "              [--capatfver <pending_version>]"
+  echo "              [--capuefiver <pending_version>]"
 }
 
 dump_mode=0
@@ -3204,7 +3231,7 @@ infile=
 skip_mfg=0
 
 # Parse the arguments.
-options=$(getopt -n bfcfg -o dl:ohvpc:b:s -l dump,dump-level:,dump-osarg,help,part-info,cfg2bin:,bin2cfg:,skip-mfg,version,hscv -- "$@")
+options=$(getopt -n bfcfg -o dl:ohvpc:b:s -l dump,dump-level:,dump-osarg,help,part-info,cfg2bin:,bin2cfg:,skip-mfg,version,hscv,capatfver,capuefiver -- "$@")
 eval set -- "$options"
 while [ "$1" != -- ]; do
   case $1 in
@@ -3216,6 +3243,8 @@ while [ "$1" != -- ]; do
     --skip-mfg) skip_mfg=1 ;;
     --cfg2bin|-c) has_cfg2bin=1; infile=$2 ;;
     --bin2cfg|-b) has_bin2cfg=1; infile=$2 ;;
+    --capatfver) set_cap_atf_version $3; exit 0 ;;
+    --capuefiver) set_cap_uefi_version $3; exit 0 ;;
     --version|-v) echo "$0 version '$bfcfg_version'"; exit 0 ;;
     --hscv|-s) echo "$0 highest supported config version: $PCP_VERSION"; exit 0 ;;
   esac

--- a/bfrec
+++ b/bfrec
@@ -224,6 +224,29 @@ uefi_capsule_update()
         "${efivars}/${os_var}"
     $run sync
 
+    # Use bfver to parse the ATF and UEFI version from the capsule file.
+    BFVER_OUTPUT=$(bfver -f $capsule_file)
+
+    atf_version=""
+    uefi_version=""
+    while IFS= read -r line; do
+        if [[ $line == *"BlueField ATF version:"* ]]; then
+            atf_version=$(echo "$line" | cut -d':' -f3 | xargs)
+        elif [[ $line == *"BlueField UEFI version:"* ]]; then
+            uefi_version=$(echo "$line" | cut -d':' -f2 | xargs)
+        fi
+    done <<< "$BFVER_OUTPUT"
+
+    # Verify that versions were successfully parsed
+    if [ -z "$atf_version" ] || [ -z "$uefi_version" ]; then
+        echo "ERROR: Failed to parse ATF or UEFI version from capsule file" >&2
+        exit 2
+    fi
+
+    # Transfer the ATF and UEFI pending version to UEFI.
+    bfcfg --capatfver $atf_version
+    bfcfg --capuefiver $uefi_version
+
     cat <<EOF
 
     ***********************************************************************

--- a/bfver
+++ b/bfver
@@ -92,6 +92,61 @@ print_bfb_installed_vers () {
     print_bfb_file_vers "$CURRENT_BFB" "$DEV_PATH"
 }
 
+print_capsule_file_vers () {
+    # Print versions stored in files.
+    BFB_PATH="$1"
+
+    # UEFI image header
+    pattern="4266021321003005"
+    uefi_image_file="$TMP_DIR/temp_uefi_image.bin"
+
+    atf_version=$(strings "$BFB_PATH" | grep -m 1 "(\(release\|debug\))")
+    if [ -n "$atf_version" ]; then
+        echo BlueField ATF version: "$atf_version"
+    fi
+
+    # Search for the UEFI header pattern
+    xxd -p "$BFB_PATH" | tr -d "\n" | grep -b -o "$pattern" | cut -d: -f1 | while read -r header_offset2; do
+        header_offset=$(($header_offset2/2))
+        image_offset=$((header_offset + 24))
+
+        header_string=$(xxd -p -s $header_offset -l 24 "$BFB_PATH")
+
+        if echo "$header_string" | grep -q "^$pattern"; then
+            # Extract the image length (next 4 bytes after the header)
+            image_len_hex=$(echo "$header_string" | cut -c 17-24)
+            image_len=$(echo "$image_len_hex" | sed 's/\(..\)\(..\)\(..\)\(..\)/\4\3\2\1/')
+            image_len_dec=$(printf "%d" "0x${image_len#0*}")
+
+            # Check the image offset and length against the input file length
+            input_file_length=$(stat -c%s "$BFB_PATH")
+            end_position=$((image_offset + image_len_dec))
+            if [ "$end_position" -gt "$input_file_length" ]; then
+                echo "Error: Image offset + length is greater than input file length"
+                exit 1
+            fi
+
+            # Extract the UEFI image
+            tail -c +$((image_offset + 1)) "$BFB_PATH" | head -c $image_len_dec > "$uefi_image_file"
+
+            # Fetch the version from the UEFI image
+            gzipped=$(file $uefi_image_file | grep gzip)
+            if [ -n "$gzipped" ]; then
+                mv $uefi_image_file $uefi_image_file.gz
+                gunzip $uefi_image_file.gz
+                uefi_version="$(strings -el $uefi_image_file | grep "BlueField" | cut -d':' -f 2)"
+            else
+                echo "Warning: UEFI image not compressed and no version info"
+            fi
+
+            rm $uefi_image_file
+
+            echo BlueField UEFI version: $uefi_version
+            echo
+        fi
+    done
+}
+
 print_bfb_file_vers () {
     # Print versions stored in files.
     BFB_PATH="$1"
@@ -105,6 +160,14 @@ print_bfb_file_vers () {
     fi
 
     echo "--$DISPLAY_NAME"
+
+    # Check for EFI Firmware Management Capsule GUID
+    # EFI_FIRMWARE_MANAGEMENT_CAPSULE_ID_GUID: 6dcbd5ed-e82d-4c44-bda1-7194199ad92a
+    local capguid=$(dd if="${BFB_PATH}" skip=0 count=16 bs=1 2>/dev/null | xxd -p)
+    if [ "$capguid" = "edd5cb6d2de8444cbda17194199ad92a" ]; then
+        print_capsule_file_vers "$DISPLAY_NAME"
+        exit 0
+    fi
 
     # Find and print the ATF version
     echo BlueField ATF version: "$(strings "$BFB_PATH" | grep -m 1 "(\(release\|debug\))")"


### PR DESCRIPTION
bfver: Add support to fetch ATF and UEFI versions from capsule files.

bfcfg: Add a new debug EFI varialbe to transfer ATF and UEFI versions to UEFI.

bfrec: In uefi_capsule_update(), call bfver to fetch the ATF and UEFI versions, and call bfcfg to transfer the versions to UEFI.
