### PR TITLE
bfcfg: remove newline character from the ATF and UEFI version strings.

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -3239,7 +3239,7 @@ print_osarg()
 set_cap_atf_version()
 {
   printf "\\x06\\x00\\x00\\x00" > ${tmpdir}/cap_atf_version
-  echo "$1" >> ${tmpdir}/cap_atf_version
+  echo -n "$1" >> ${tmpdir}/cap_atf_version
 
   cp ${tmpdir}/cap_atf_version "${cap_atf_version_sysfs}" 2>/dev/null
 }
@@ -3250,7 +3250,7 @@ set_cap_atf_version()
 set_cap_uefi_version()
 {
   printf "\\x06\\x00\\x00\\x00" > ${tmpdir}/cap_uefi_version
-  echo "$1" >> ${tmpdir}/cap_uefi_version
+  echo -n "$1" >> ${tmpdir}/cap_uefi_version
 
   cp ${tmpdir}/cap_uefi_version "${cap_uefi_version_sysfs}" 2>/dev/null
 }


### PR DESCRIPTION
The newline was adding in bfcfg by the echo command. Removed the newline character by adding the "-n" option.