### PR TITLE
bfrec update for bug fixing in 4.9.x.

### DIFF
--- a/bfrec
+++ b/bfrec
@@ -146,6 +146,57 @@ fi
 bfb_location=/lib/firmware/mellanox/boot
 capsule_location=/lib/firmware/mellanox/boot/capsule
 
+parse_and_set_capsule_versions()
+{
+    local capsule_file="$1"
+
+    if [ -z "$capsule_file" ]; then
+        echo "ERROR: No capsule file specified"
+        exit 2
+    fi
+
+    if [ ! -f "$capsule_file" ]; then
+        echo "ERROR: Capsule file '$capsule_file' not found"
+        exit 2
+    fi
+
+    # Check if bfver command is available
+    if ! command -v bfver >/dev/null 2>&1; then
+        echo "Boot image parsing: bfver command not found, skipping"
+        return 0
+    fi
+
+    # Use bfver to parse the ATF and UEFI version from the capsule file.
+    BFVER_OUTPUT=$(bfver -f "$capsule_file")
+
+    local atf_version=""
+    local uefi_version=""
+    while IFS= read -r line; do
+        if [[ $line == *"BlueField ATF version:"* ]]; then
+            atf_version=$(echo "$line" | cut -d':' -f3 | xargs)
+        elif [[ $line == *"BlueField UEFI version:"* ]]; then
+            uefi_version=$(echo "$line" | cut -d':' -f2 | xargs)
+        fi
+    done <<< "$BFVER_OUTPUT"
+
+    # Check if both versions were successfully parsed
+    if [ -n "$atf_version" ] && [ -n "$uefi_version" ]; then
+        # Check if bfver command is available
+        if ! command -v bfcfg >/dev/null 2>&1; then
+            echo "Boot image parsing: bfcfg command not found, skipping"
+            return 0
+        fi
+
+        # Transfer the ATF and UEFI pending version to UEFI.
+        bfcfg --capatfver "$atf_version"
+        bfcfg --capuefiver "$uefi_version"
+
+        echo "Boot image detected: ATF pending version: $atf_version, UEFI pending version: $uefi_version"
+    fi
+
+    return 0
+}
+
 uefi_capsule_update()
 {
     # Set capsule update file variable name
@@ -224,28 +275,8 @@ uefi_capsule_update()
         "${efivars}/${os_var}"
     $run sync
 
-    # Use bfver to parse the ATF and UEFI version from the capsule file.
-    BFVER_OUTPUT=$(bfver -f $capsule_file)
-
-    atf_version=""
-    uefi_version=""
-    while IFS= read -r line; do
-        if [[ $line == *"BlueField ATF version:"* ]]; then
-            atf_version=$(echo "$line" | cut -d':' -f3 | xargs)
-        elif [[ $line == *"BlueField UEFI version:"* ]]; then
-            uefi_version=$(echo "$line" | cut -d':' -f2 | xargs)
-        fi
-    done <<< "$BFVER_OUTPUT"
-
-    # Verify that versions were successfully parsed
-    if [ -z "$atf_version" ] || [ -z "$uefi_version" ]; then
-        echo "ERROR: Failed to parse ATF or UEFI version from capsule file" >&2
-        exit 2
-    fi
-
-    # Transfer the ATF and UEFI pending version to UEFI.
-    bfcfg --capatfver $atf_version
-    bfcfg --capuefiver $uefi_version
+    # Parse and set capsule firmware versions
+    parse_and_set_capsule_versions $capsule_file || true
 
     cat <<EOF
 


### PR DESCRIPTION
fix the error message and return code when the capsule file does not
contain ATF or UEFI versions.

Created a new function parse_and_set_capsule_versions() to hanlde the logic of
parsing the ATF and UEFI versions from the capsule file, and call bfcfg to
transfer the versions to UEFI.

RM #4516610