### PR TITLE
bfsbverify: omit fixed salt length verification for RSA SSA-PSS

### DIFF
--- a/bfsbverify
+++ b/bfsbverify
@@ -540,7 +540,7 @@ verify_cert_sig()
     # Set OpenSSL arguments for signature verification. 
     opensslargs=
     if [ "$alg" = "rsassaPss" ]; then
-        opensslargs="-sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:32 -sigopt rsa_mgf1_md:sha512"
+        opensslargs="-sigopt rsa_padding_mode:pss -sigopt rsa_mgf1_md:sha512"
     fi
 
     # Verify certificate signature.


### PR DESCRIPTION
The RSA SSA-PSS salt length is usually determined based on the hash algorithm associated with the RSA operation. Thus omit option to check the salt length '-sigopt rsa_pss_saltlen:32'.

Note that a length of 32 would support signature generated with SHA256 hash.

RM #4518312