### PR TITLE
bfcfg: Fix backslash bug for BOOTx_DEVPATH variable

### DIFF
--- a/bfcfg
+++ b/bfcfg
@@ -37,7 +37,7 @@ TMP_DIR=$(mktemp -d)
 trap "rm -rf $TMP_DIR" EXIT
 trap "rm -rf $TMP_DIR; exit 1" TERM INT
 
-bfcfg_version=4.6
+bfcfg_version=4.7
 bfcfg_rc=0
 cfg_file=/etc/bf.cfg
 log_file=/tmp/bfcfg.log
@@ -1934,6 +1934,16 @@ arm_cfg_get_value()
       || [ "$name" = "PXE_DHCP_CLASS_ID" ] \
       || [ "$name" = "BF_BUNDLE_VERSION" ]; then
       value=$(dd if=${in_file} skip=${offset} count=${size} bs=1 2> /dev/null | tr -d '\0')
+
+      # For BOOTX_DEVPATH, when converting from binary back to text,
+      # we need to ESC the backslashes. This is so if we later
+      # convert that configuration back to binary, the path is
+      # preserved correctly.
+      # Example: "\EFI\debian\grubaa64.efi"  ==> "\\EFI\\debian\\grubaa64.efi"
+      if [[ "$name" == "BOOT"*"_DEVPATH" ]]; then
+         value=${value//\\/\\\\}
+      fi
+
       if [[ "$name" == "BOOT"*"_DESC" ]] \
       || [[ "$name" == "BOOT"*"_ARGS" ]] \
       || [[ "$name" == "BOOT"*"_DEVPATH" ]]; then


### PR DESCRIPTION
When converting a binary configuration file back to text, if the BOOTx_DEVPATH variable is set, the text written back is incorrect, because if you then try converting that text back to a binary config file, the data gets corrupted in the binary config file.

Example:
Start out with: BOOT0_DEVPATH='\\EFI\\velinux\\grubaa64.efi' Convert to binary, this gets saved as '\EFI\velinux\grubaa64.efi' Convert that binary back to text and you will have: BOOT0_DEVPATH='\EFI\velinux\grubaa64.efi'
If you now convert that text file back to binary,
the resulting binary config will be corrupted as
bfcfg is expecting the double backslash '\\'

The fix is to simply make sure when converting from binary to text, for the DEVPATH variables, write the double slash.

Note: changed bfcfg version
from bfcfg_version=4.6
to   bfcfg_version=4.7

RM #4836088