### PR TITLE
Fixed mlxbf-scripts should not depend on mlxbf-bootimages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Git: https://github.com/Mellanox/bfscripts.git
 
 Package: mlxbf-scripts
 Architecture: any
-Depends: ${misc:Depends}, mlxbf-bootctl, mlxbf-bootimages | mlxbf-bootimages-devsigned | mlxbf-bootimages-signed, python3, gzip
+Depends: ${misc:Depends}, mlxbf-bootctl, python3, gzip
+Recommends: mlxbf-bootimages | mlxbf-bootimages-devsigned | mlxbf-bootimages-signed
 Description: Contains Mellanox BlueField scripts
  Contains Mellanox BlueField scripts that serve different ancillary purposes.

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -17,7 +17,8 @@ BuildRequires: /usr/bin/pathfix.py
 
 Requires: mlxbf-bootctl
 # Note: mlxbf-bootimages is provided by mlxbf-aarch64-firmware on Fedora.
-Requires: mlxbf-bootimages
+# Not required on BlueField-4; kept as a weak dependency for BF1/BF2/BF3.
+Recommends: mlxbf-bootimages
 Requires: bash
 Requires: python3
 Requires: grub2-tools
@@ -29,6 +30,7 @@ Requires: util-linux
 Requires: binutils
 Requires: systemd
 Requires: gzip
+
 
 %description
 Useful scripts for managing Mellanox BlueField hardware.

--- a/mlxbf-bfscripts.spec.rpkg
+++ b/mlxbf-bfscripts.spec.rpkg
@@ -22,7 +22,8 @@ BuildRequires: /usr/bin/pathfix.py
 
 Requires: mlxbf-bootctl
 # Note: mlxbf-bootimages is provided by mlxbf-aarch64-firmware on Fedora.
-Requires: mlxbf-bootimages
+# Not required on BlueField-4; kept as a weak dependency for BF1/BF2/BF3.
+Recommends: mlxbf-bootimages
 Requires: bash
 Requires: python3
 Requires: grub2-tools


### PR DESCRIPTION
 Debian:
      apt install --no-install-recommends mlxbf-scripts

    To remove:
       apt remove mlxbf-bootimages mlxbf-bootimages-devsigned mlxbf-bootimages-signed
       apt-mark manual mlxbf-scripts

RPM / Fedora / RHEL(dnf)
      dnf install --setopt=install_weak_deps=False mlxbf-bfscripts
      yum install mlxbf-bfscripts --setopt=install_weak_deps=0

    To remove:
      dnf remove mlxbf-bootimages

RM #4951903