### PR TITLE
Add new timed service to trigger RTC date repair

### DIFF
--- a/80-bfrtc-poll.preset
+++ b/80-bfrtc-poll.preset
@@ -1,0 +1,1 @@
+enable bfrtc-poll.timer

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Overview of each file:
 - **mlx-mkbfb** Builds and extracts BFB files.
 - **bfup** Informs that linux is running via rshlog message and gpio pin
 - **bfup.services** Companion service to bfup, runs bfup at boot time.
+- **bfrtc-poll** Read RTC time to trigger FW repair of invalid dates.
+- **bfrtc-poll.timer** Companion timer to bfrtc-poll, runs bfrtc-poll periodically.

--- a/bfrtc-poll
+++ b/bfrtc-poll
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Read RTC time to trigger FW repair of invalid dates
+if command -v hwclock >/dev/null 2>&1; then
+	if command -v timeout >/dev/null 2>&1; then
+		timeout 5 hwclock --show >/dev/null 2>&1
+	else
+		hwclock --show >/dev/null 2>&1
+	fi
+fi

--- a/bfrtc-poll.service
+++ b/bfrtc-poll.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Read RTC time to trigger FW repair of invalid dates
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bfrtc-poll
+StandardOutput=journal+console
+StandardError=journal

--- a/bfrtc-poll.timer
+++ b/bfrtc-poll.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically read RTC time to trigger FW repair of invalid dates
+
+[Timer]
+OnBootSec=30min
+OnUnitActiveSec=30min
+AccuracySec=1min
+Unit=bfrtc-poll.service
+
+[Install]
+WantedBy=timers.target

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: https://github.com/Mellanox/bfscripts.git
 
 Package: mlxbf-scripts
 Architecture: any
-Depends: ${misc:Depends}, mlxbf-bootctl, python3, gzip
+Depends: ${misc:Depends}, mlxbf-bootctl, python3, gzip, util-linux
 Recommends: mlxbf-bootimages | mlxbf-bootimages-devsigned | mlxbf-bootimages-signed
 Description: Contains Mellanox BlueField scripts
  Contains Mellanox BlueField scripts that serve different ancillary purposes.

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,4 @@
 bfacpievt bfbootmgr bfcfg bfcpu-freq bfdracut bffamily bfgrubcheck bfinst bfup bftraining_results usr/bin/
-bfpart bfperf_pmc bfpxe bfrec bfrshlog bfsbdump bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw usr/bin/
-bfvcheck.service bfup.service lib/systemd/system/
+bfpart bfperf_pmc bfpxe bfrec bfrshlog bfsbdump bfsbkeys bfsbverify bfvcheck bfver mlx-mkbfb bfhcafw bfrtc-poll usr/bin/
+bfvcheck.service bfup.service bfrtc-poll.service bfrtc-poll.timer lib/systemd/system/
 mlx-uefi.quirk usr/share/fwupd/quirks.d/

--- a/debian/postinst
+++ b/debian/postinst
@@ -12,10 +12,12 @@ if which deb-systemd-helper >/dev/null 2>/dev/null; then
 
 	deb-systemd-helper "$OPTS" enable bfvcheck.service
 	deb-systemd-helper "$OPTS" enable bfup.service
+	deb-systemd-helper "$OPTS" enable bfrtc-poll.timer
 
 	if [ -z "$D" ]; then
 		deb-systemd-helper restart bfvcheck.service
 		deb-systemd-helper restart bfup.service
+		deb-systemd-helper restart bfrtc-poll.timer
 	fi
 fi
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -10,10 +10,12 @@ if which deb-systemd-helper >/dev/null 2>/dev/null; then
 	if [ -z "$D" ]; then
 		deb-systemd-helper stop bfvcheck.service
 		deb-systemd-helper stop bfup.service
+		deb-systemd-helper stop bfrtc-poll.timer
 	fi
 
 	deb-systemd-helper "$OPTS" disable bfvcheck.service
 	deb-systemd-helper "$OPTS" disable bfup.service
+	deb-systemd-helper "$OPTS" disable bfrtc-poll.timer
 fi
 
 #DEBHELPER#

--- a/man/bfrtc-poll.8
+++ b/man/bfrtc-poll.8
@@ -1,0 +1,11 @@
+.TH BFRTC-POLL 8 "July 2026"
+.SH NAME
+bfrtc-poll \- Read RTC time to trigger firmware repair of invalid dates
+.SH SYNOPSIS
+.B bfrtc-poll
+.SH DESCRIPTION
+Reads the hardware RTC and discards the output. The RTC read triggers firmware
+repair of invalid RTC dates on affected BlueField systems.
+.SH OPTIONS
+.B bfrtc-poll
+accepts no options.

--- a/mlxbf-bfscripts.spec
+++ b/mlxbf-bfscripts.spec
@@ -94,14 +94,19 @@ install -p mlx-mkbfb       %{installdir}
 install -p man/mlx-mkbfb.1 %{man1dir}
 install -p bftraining_results %{installdir}
 install -p man/bftraining_results.8 %{man8dir}
+install -p bfrtc-poll %{installdir}
+install -p man/bfrtc-poll.8 %{man8dir}
 
 install -p -d %{buildroot}%{_unitdir}
 install -p bfvcheck.service %{buildroot}%{_unitdir}/
 install -p bfup.service %{buildroot}%{_unitdir}/
+install -p bfrtc-poll.service %{buildroot}%{_unitdir}/
+install -p bfrtc-poll.timer %{buildroot}%{_unitdir}/
 
 install -p -d %{buildroot}%{_presetdir}
 install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 install -p 80-bfup.preset %{buildroot}%{_presetdir}/
+install -p 80-bfrtc-poll.preset %{buildroot}%{_presetdir}/
 
 # Install tweak for fwupd on BlueField
 %global fwupdquirkdir %{buildroot}%{_datadir}/fwupd/quirks.d
@@ -111,14 +116,17 @@ install -p mlx-uefi.quirk %{fwupdquirkdir}/
 %post
 %systemd_post bfvcheck.service
 %systemd_post bfup.service
+%systemd_post bfrtc-poll.timer
 
 %preun
 %systemd_preun bfvcheck.service
 %systemd_preun bfup.service
+%systemd_preun bfrtc-poll.timer
 
 %postun
 %systemd_postun bfvcheck.service
 %systemd_postun bfup.service
+%systemd_postun bfrtc-poll.timer
 
 %files
 %license LICENSE
@@ -128,8 +136,11 @@ install -p mlx-uefi.quirk %{fwupdquirkdir}/
 %attr(644, root, root) %{_mandir}/man8/*
 %attr(644, root, root) %{_unitdir}/bfvcheck.service
 %attr(644, root, root) %{_unitdir}/bfup.service
+%attr(644, root, root) %{_unitdir}/bfrtc-poll.service
+%attr(644, root, root) %{_unitdir}/bfrtc-poll.timer
 %attr(644, root, root) %{_presetdir}/80-bfvcheck.preset
 %attr(644, root, root) %{_presetdir}/80-bfup.preset
+%attr(644, root, root) %{_presetdir}/80-bfrtc-poll.preset
 %attr(644, root, root) %{_datadir}/fwupd/quirks.d/mlx-uefi.quirk
 
 %doc README.md

--- a/mlxbf-bfscripts.spec.rpkg
+++ b/mlxbf-bfscripts.spec.rpkg
@@ -93,6 +93,8 @@ install -p bfrshlog          %{installdir}
 install -p man/bfrshlog.8    %{man8dir}
 install -p bfup              %{installdir}
 install -p man/bfup.8        %{man8dir}
+install -p bfrtc-poll        %{installdir}
+install -p man/bfrtc-poll.8  %{man8dir}
 
 install -p mlx-mkbfb       %{installdir}
 install -p man/mlx-mkbfb.1 %{man1dir}
@@ -100,10 +102,13 @@ install -p man/mlx-mkbfb.1 %{man1dir}
 install -p -d %{buildroot}%{_unitdir}
 install -p bfvcheck.service %{buildroot}%{_unitdir}/
 install -p bfup.service %{buildroot}%{_unitdir}/
+install -p bfrtc-poll.service %{buildroot}%{_unitdir}/
+install -p bfrtc-poll.timer %{buildroot}%{_unitdir}/
 
 install -p -d %{buildroot}%{_presetdir}
 install -p 80-bfvcheck.preset %{buildroot}%{_presetdir}/
 install -p 80-bfup.preset %{buildroot}%{_presetdir}/
+install -p 80-bfrtc-poll.preset %{buildroot}%{_presetdir}/
 
 # Install tweak for fwupd on BlueField
 %global fwupdquirkdir %{buildroot}%{_datadir}/fwupd/quirks.d
@@ -113,14 +118,17 @@ install -p mlx-uefi.quirk %{fwupdquirkdir}/
 %post
 %systemd_post bfvcheck.service
 %systemd_post bfup.service
+%systemd_post bfrtc-poll.timer
 
 %preun
 %systemd_preun bfvcheck.service
 %systemd_preun bfup.service
+%systemd_preun bfrtc-poll.timer
 
 %postun
 %systemd_postun bfvcheck.service
 %systemd_postun bfup.service
+%systemd_postun bfrtc-poll.timer
 
 %files
 %license LICENSE
@@ -130,8 +138,11 @@ install -p mlx-uefi.quirk %{fwupdquirkdir}/
 %attr(644, root, root) %{_mandir}/man8/*
 %attr(644, root, root) %{_unitdir}/bfvcheck.service
 %attr(644, root, root) %{_unitdir}/bfup.service
+%attr(644, root, root) %{_unitdir}/bfrtc-poll.service
+%attr(644, root, root) %{_unitdir}/bfrtc-poll.timer
 %attr(644, root, root) %{_presetdir}/80-bfvcheck.preset
 %attr(644, root, root) %{_presetdir}/80-bfup.preset
+%attr(644, root, root) %{_presetdir}/80-bfrtc-poll.preset
 %attr(644, root, root) %{_datadir}/fwupd/quirks.d/mlx-uefi.quirk
 
 %doc README.md


### PR DESCRIPTION
It is possible for the RTC date to become corrupted on BF2 and BF3 due to an old firmware issue that has recently been fixed. As part of this fix, new firmware can now automatically detect and repair invalid dates when UEFI GetTime is called.

Create a new service and timer to periodically read the RTC time using "hwclock". If the RTC is programmed with an invalid date then reading the time will automatically trigger date repair.

This service is added to help prevent cases that can cause RTC corruption over time without NTP sync.

RM #4966842