### PR TITLE
bfpxe: fall back to dhcpcd when dhclient/udhcpc are unavailable (RHEL 10)

### DIFF
--- a/bfpxe
+++ b/bfpxe
@@ -99,6 +99,8 @@ EOF
     if [ "$ifaddr" = "dhcp6" ]; then
       if [ -x /sbin/dhclient ]; then
         /sbin/dhclient -6 "$ifname"
+      elif [ -x /usr/sbin/dhcpcd ]; then
+        /usr/sbin/dhcpcd -6 -w -t 30 "$ifname"
       fi
       if [ -n "$TMP_MNT" ]; then
         sed -i '/Address =/d' "$TMP_MNT"/etc/systemd/network/05-"${ifname}".network
@@ -109,6 +111,8 @@ EOF
       ifconfig "$ifname" 0.0.0.0 up
       if [ -x /sbin/dhclient ]; then
         /sbin/dhclient "$ifname"
+      elif [ -x /usr/sbin/dhcpcd ]; then
+        /usr/sbin/dhcpcd -4 -w -t 30 "$ifname"
       else
         udhcpc -R -b -A 5 -T 3 -t 10 -i "$ifname"
       fi


### PR DESCRIPTION
## Problem
On RHEL 10, `bfpxe` cannot bring up the network during a PXE install. RHEL 10 removed the ISC `dhclient`, and there is no `udhcpc` (busybox) either. `create_net()` tries `/sbin/dhclient` then falls back to `udhcpc`, so on RHEL 10 both are missing, the interface never gets an address, and the `bf.cfg` download fails (`udhcpc: command not found`, then `Network is unreachable`).

## Fix
Add `dhcpcd` (the RHEL 10 DHCP client) as a last-resort fallback in `create_net()`:
- IPv4: `dhclient` -> `udhcpc` (now guarded) -> `dhcpcd -4 -w -t 30`
- IPv6: `dhclient` -> `dhcpcd -6 -w -t 30`

Existing `dhclient`/`udhcpc` paths are unchanged; `dhcpcd` runs only when neither exists (i.e. RHEL 10). This also guards the previously-unconditional `udhcpc` else.

## Testing
Verified on BlueField-3 / RHEL 10.2 via PXE install -- `bf.cfg` now downloads:
```
Connecting to 192.168.40.1:80... connected.
HTTP request sent, awaiting response... 200 OK.
'bf.cfg' saved [711/711].
```

Redmine: #5130650