### PR TITLE
Disable bfrtc-poll on BF4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Overview of each file:
 - **mlx-mkbfb** Builds and extracts BFB files.
 - **bfup** Informs that linux is running via rshlog message and gpio pin
 - **bfup.services** Companion service to bfup, runs bfup at boot time.
-- **bfrtc-poll** Read RTC time to trigger FW repair of invalid dates.
+- **bfrtc-poll** Read RTC time to trigger FW repair of invalid dates. ***(Not supported on BlueField-4.)***
 - **bfrtc-poll.timer** Companion timer to bfrtc-poll, runs bfrtc-poll periodically.

--- a/bfrtc-poll
+++ b/bfrtc-poll
@@ -1,4 +1,13 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+bf_chip=$(bffamily --chip)
+
+# Not necessary on BF4
+if [ "$bf_chip" = "BlueField-4" ]; then
+	exit 0
+fi
 
 # Read RTC time to trigger FW repair of invalid dates
 if command -v hwclock >/dev/null 2>&1; then


### PR DESCRIPTION
The bfrtc-poll script is not needed for RTC correction on BF4. Exit early from the script if running on BF4.

RM #5177614